### PR TITLE
Extended uptime exaflares

### DIFF
--- a/triggers/src/main/java/gg/xp/xivsupport/events/triggers/duties/ewult/DragonsongUptimeExas.java
+++ b/triggers/src/main/java/gg/xp/xivsupport/events/triggers/duties/ewult/DragonsongUptimeExas.java
@@ -119,45 +119,7 @@ public class DragonsongUptimeExas extends AutoChildEventHandler implements Filte
 				ArenaSector eastFacing = ArenaPos.combatantFacing(eastExaPos.getHeading());
 
 				log.info("Uptime exaflares: S {}, NW {}, NE {}", southFacing, westFacing, eastFacing);
-
-				List<UptimeExaflareMovement> safeSpots = new ArrayList<>(getPriority().get());
-				// Remove things that S will hit
-				if (willExaHitDirection(ArenaSector.NORTHWEST, southFacing)) {
-					safeSpots.remove(UptimeExaflareMovement.NORTHWEST_PLANT);
-				}
-				if (willExaHitDirection(ArenaSector.NORTHEAST, southFacing)) {
-					safeSpots.remove(UptimeExaflareMovement.NORTHEAST_PLANT);
-				}
-				if (willExaHitDirection(ArenaSector.NORTH, southFacing)) {
-					safeSpots.remove(UptimeExaflareMovement.SOUTH_NORTH);
-					safeSpots.remove(UptimeExaflareMovement.SOUTH_NORTH_NARROW);
-				}
-				// Remove things that NW will hit
-				if (willExaHitDirection(ArenaSector.EAST, westFacing)) {
-					safeSpots.remove(UptimeExaflareMovement.NORTHEAST_PLANT);
-					safeSpots.remove(UptimeExaflareMovement.SOUTH_NORTH);
-				}
-				if (willExaHitDirection(ArenaSector.SOUTH, westFacing)) {
-					safeSpots.remove(UptimeExaflareMovement.SOUTH_WEST);
-				}
-				if (willExaHitDirection(ArenaSector.SOUTHEAST, westFacing)) {
-					safeSpots.remove(UptimeExaflareMovement.SOUTH_PLANT);
-					safeSpots.remove(UptimeExaflareMovement.SOUTH_EAST);
-				}
-				// Remove things that NE will hit
-				if (willExaHitDirection(ArenaSector.WEST, eastFacing)) {
-					safeSpots.remove(UptimeExaflareMovement.NORTHWEST_PLANT);
-					safeSpots.remove(UptimeExaflareMovement.SOUTH_NORTH);
-				}
-				if (willExaHitDirection(ArenaSector.SOUTH, eastFacing)) {
-					safeSpots.remove(UptimeExaflareMovement.SOUTH_EAST);
-				}
-				if (willExaHitDirection(ArenaSector.SOUTHWEST, eastFacing)) {
-					safeSpots.remove(UptimeExaflareMovement.SOUTH_PLANT);
-					safeSpots.remove(UptimeExaflareMovement.SOUTH_WEST);
-				}
-
-				log.info("Computed safe strats: {}", safeSpots);
+				List<UptimeExaflareMovement> safeSpots = getSafeMovements(southFacing, westFacing, eastFacing);
 				final ModifiableCallout<AbilityCastStart> call;
 				if (safeSpots.isEmpty()) {
 					// Should never happen, just in case
@@ -178,6 +140,50 @@ public class DragonsongUptimeExas extends AutoChildEventHandler implements Filte
 				s.updateCall(call.getModified(realThordanCast));
 			}
 	);
+
+	// TODO: unit test
+	final List<UptimeExaflareMovement> getSafeMovements(ArenaSector southFacing, ArenaSector westFacing, ArenaSector eastFacing) {
+		List<UptimeExaflareMovement> safeSpots = new ArrayList<>(getPriority().get());
+		// Remove things that S will hit
+		if (willExaHitDirection(ArenaSector.NORTHWEST, southFacing)) {
+			safeSpots.remove(UptimeExaflareMovement.NORTHWEST_PLANT);
+		}
+		if (willExaHitDirection(ArenaSector.NORTHEAST, southFacing)) {
+			safeSpots.remove(UptimeExaflareMovement.NORTHEAST_PLANT);
+		}
+		if (willExaHitDirection(ArenaSector.NORTH, southFacing)) {
+			safeSpots.remove(UptimeExaflareMovement.SOUTH_NORTH);
+			safeSpots.remove(UptimeExaflareMovement.SOUTH_NORTH_NARROW);
+		}
+		// Remove things that NW will hit
+		if (willExaHitDirection(ArenaSector.EAST, westFacing)) {
+			safeSpots.remove(UptimeExaflareMovement.NORTHEAST_PLANT);
+			safeSpots.remove(UptimeExaflareMovement.SOUTH_NORTH);
+		}
+		if (willExaHitDirection(ArenaSector.SOUTH, westFacing)) {
+			safeSpots.remove(UptimeExaflareMovement.SOUTH_WEST);
+		}
+		if (willExaHitDirection(ArenaSector.SOUTHEAST, westFacing)) {
+			safeSpots.remove(UptimeExaflareMovement.SOUTH_PLANT);
+			safeSpots.remove(UptimeExaflareMovement.SOUTH_EAST);
+		}
+		// Remove things that NE will hit
+		if (willExaHitDirection(ArenaSector.WEST, eastFacing)) {
+			safeSpots.remove(UptimeExaflareMovement.NORTHWEST_PLANT);
+			safeSpots.remove(UptimeExaflareMovement.SOUTH_NORTH);
+		}
+		if (willExaHitDirection(ArenaSector.SOUTH, eastFacing)) {
+			safeSpots.remove(UptimeExaflareMovement.SOUTH_EAST);
+		}
+		if (willExaHitDirection(ArenaSector.SOUTHWEST, eastFacing)) {
+			safeSpots.remove(UptimeExaflareMovement.SOUTH_PLANT);
+			safeSpots.remove(UptimeExaflareMovement.SOUTH_WEST);
+		}
+
+		log.info("Computed safe strats: {}", safeSpots);
+		return safeSpots;
+
+	}
 
 	@Override
 	public BooleanSetting getCalloutGroupEnabledSetting() {

--- a/triggers/src/main/java/gg/xp/xivsupport/events/triggers/duties/ewult/DragonsongUptimeExas.java
+++ b/triggers/src/main/java/gg/xp/xivsupport/events/triggers/duties/ewult/DragonsongUptimeExas.java
@@ -46,6 +46,7 @@ public class DragonsongUptimeExas extends AutoChildEventHandler implements Filte
 	private final ModifiableCallout<AbilityCastStart> northwestPlant = new ModifiableCallout<>("Northwest Plant", "Northwest Plant", 8_000);
 	private final ModifiableCallout<AbilityCastStart> northeastPlant = new ModifiableCallout<>("Northeast Plant", "Northeast Plant", 8_000);
 	private final ModifiableCallout<AbilityCastStart> badPattern = new ModifiableCallout<>("Bad Pattern", "Downtime Pattern", 8_000);
+	private final ModifiableCallout<AbilityCastStart> error = new ModifiableCallout<>("Trigger Error", "Downtime Pattern", 8_000);
 
 	// TODO: make tests for this
 	public DragonsongUptimeExas(XivState state, PersistenceProvider pers) {
@@ -105,6 +106,7 @@ public class DragonsongUptimeExas extends AutoChildEventHandler implements Filte
 						.toList();
 				if (normalizedExaPositions.size() != 3) {
 					log.error("Missing an exaflare actor! Data: {} - {}", exaCasts, normalizedExaPositions);
+					s.updateCall(error.getModified(realThordanCast));
 					return;
 				}
 				log.info("Uptime exas: computing");

--- a/triggers/src/main/java/gg/xp/xivsupport/events/triggers/duties/ewult/DragonsongUptimeExas.java
+++ b/triggers/src/main/java/gg/xp/xivsupport/events/triggers/duties/ewult/DragonsongUptimeExas.java
@@ -39,7 +39,8 @@ public class DragonsongUptimeExas extends AutoChildEventHandler implements Filte
 	private final EnumListSetting<UptimeExaflareMovement> priority;
 
 	private final ModifiableCallout<AbilityCastStart> southPlant = new ModifiableCallout<>("South Plant", "South Plant", 8_000);
-	private final ModifiableCallout<AbilityCastStart> southNorth = new ModifiableCallout<>("South Then North", "South Then North", 8_000);
+	private final ModifiableCallout<AbilityCastStart> southNorth = new ModifiableCallout<>("South Then North (Wide)", "South Then North", 8_000);
+	private final ModifiableCallout<AbilityCastStart> southNorthNarrow = new ModifiableCallout<>("South Then North (Narrow)", "South Then North", 8_000);
 	private final ModifiableCallout<AbilityCastStart> southWest = new ModifiableCallout<>("South Then West", "South Then West", 8_000);
 	private final ModifiableCallout<AbilityCastStart> southEast = new ModifiableCallout<>("South Then East", "South Then East", 8_000);
 	private final ModifiableCallout<AbilityCastStart> northwestPlant = new ModifiableCallout<>("Northwest Plant", "Northwest Plant", 8_000);
@@ -127,10 +128,15 @@ public class DragonsongUptimeExas extends AutoChildEventHandler implements Filte
 				}
 				if (willExaHitDirection(ArenaSector.NORTH, southFacing)) {
 					safeSpots.remove(UptimeExaflareMovement.SOUTH_NORTH);
+					safeSpots.remove(UptimeExaflareMovement.SOUTH_NORTH_NARROW);
 				}
 				// Remove things that NW will hit
 				if (willExaHitDirection(ArenaSector.EAST, westFacing)) {
 					safeSpots.remove(UptimeExaflareMovement.NORTHEAST_PLANT);
+					safeSpots.remove(UptimeExaflareMovement.SOUTH_NORTH);
+				}
+				if (willExaHitDirection(ArenaSector.SOUTH, westFacing)) {
+					safeSpots.remove(UptimeExaflareMovement.SOUTH_WEST);
 				}
 				if (willExaHitDirection(ArenaSector.SOUTHEAST, westFacing)) {
 					safeSpots.remove(UptimeExaflareMovement.SOUTH_PLANT);
@@ -139,6 +145,10 @@ public class DragonsongUptimeExas extends AutoChildEventHandler implements Filte
 				// Remove things that NE will hit
 				if (willExaHitDirection(ArenaSector.WEST, eastFacing)) {
 					safeSpots.remove(UptimeExaflareMovement.NORTHWEST_PLANT);
+					safeSpots.remove(UptimeExaflareMovement.SOUTH_NORTH);
+				}
+				if (willExaHitDirection(ArenaSector.SOUTH, eastFacing)) {
+					safeSpots.remove(UptimeExaflareMovement.SOUTH_EAST);
 				}
 				if (willExaHitDirection(ArenaSector.SOUTHWEST, eastFacing)) {
 					safeSpots.remove(UptimeExaflareMovement.SOUTH_PLANT);
@@ -159,6 +169,7 @@ public class DragonsongUptimeExas extends AutoChildEventHandler implements Filte
 						case SOUTH_EAST -> southEast;
 						case NORTHWEST_PLANT -> northwestPlant;
 						case NORTHEAST_PLANT -> northeastPlant;
+						case SOUTH_NORTH_NARROW -> southNorthNarrow;
 						case DOWNTIME -> badPattern;
 					};
 				}

--- a/triggers/src/main/java/gg/xp/xivsupport/events/triggers/duties/ewult/DragonsongUptimeExas.java
+++ b/triggers/src/main/java/gg/xp/xivsupport/events/triggers/duties/ewult/DragonsongUptimeExas.java
@@ -19,10 +19,12 @@ import gg.xp.xivsupport.models.Position;
 import gg.xp.xivsupport.models.XivCombatant;
 import gg.xp.xivsupport.persistence.PersistenceProvider;
 import gg.xp.xivsupport.persistence.settings.BooleanSetting;
+import gg.xp.xivsupport.persistence.settings.EnumListSetting;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Objects;
 
@@ -34,6 +36,7 @@ public class DragonsongUptimeExas extends AutoChildEventHandler implements Filte
 	private static final Logger log = LoggerFactory.getLogger(DragonsongUptimeExas.class);
 	private final XivState state;
 	private final BooleanSetting enabled;
+	private final EnumListSetting<UptimeExaflareMovement> priority;
 
 	private final ModifiableCallout<AbilityCastStart> southPlant = new ModifiableCallout<>("South Plant", "South Plant", 8_000);
 	private final ModifiableCallout<AbilityCastStart> southNorth = new ModifiableCallout<>("South Then North", "South Then North", 8_000);
@@ -47,10 +50,15 @@ public class DragonsongUptimeExas extends AutoChildEventHandler implements Filte
 	public DragonsongUptimeExas(XivState state, PersistenceProvider pers) {
 		this.state = state;
 		this.enabled = new BooleanSetting(pers, "triggers.dragonsong.south-uptime-exas.enabled", false);
+		this.priority = new EnumListSetting<>(UptimeExaflareMovement.class, pers, "triggers.dragonsong.south-uptime-exas.prio", EnumListSetting.BadKeyBehavior.OMIT, UptimeExaflareMovement.defaultOrder());
 	}
 
 	public XivState getState() {
 		return state;
+	}
+
+	public EnumListSetting<UptimeExaflareMovement> getPriority() {
+		return priority;
 	}
 
 	@Override
@@ -66,6 +74,12 @@ public class DragonsongUptimeExas extends AutoChildEventHandler implements Filte
 		There's also a second strat, where you can just *always* plant. It appears that you cannot actually get a
 		pattern without a plantable exaflare.
 	 */
+
+	// Check if any of an exa's three directions are equal to some given direction.
+	// i.e. is 'direction' going to get hit by 'exaflarefacing' (front, left or right)
+	private static boolean willExaHitDirection(ArenaSector direction, ArenaSector exaflareFacing) {
+		return exaflareFacing == direction || exaflareFacing.plusQuads(1) == direction || exaflareFacing.plusQuads(-1) == direction;
+	}
 
 	@AutoFeed
 	private final SequentialTrigger<BaseEvent> uptimeExas = new SequentialTrigger<>(
@@ -103,57 +117,52 @@ public class DragonsongUptimeExas extends AutoChildEventHandler implements Filte
 
 				log.info("Uptime exaflares: S {}, NW {}, NE {}", southFacing, westFacing, eastFacing);
 
-				boolean sUnsafeFromW = westFacing == ArenaSector.NORTHEAST || westFacing == ArenaSector.SOUTHEAST || westFacing == ArenaSector.SOUTHWEST;
-				boolean sUnsafeFromE = eastFacing == ArenaSector.NORTHWEST || eastFacing == ArenaSector.SOUTHEAST || eastFacing == ArenaSector.SOUTHWEST;
-				boolean nUnsafeFromS = southFacing == ArenaSector.NORTH || southFacing == ArenaSector.WEST || southFacing == ArenaSector.EAST;
-				// TODO: rewrite this later
-				boolean wUnsafeFromS = southFacing == ArenaSector.NORTHWEST || southFacing == ArenaSector.NORTHEAST || southFacing == ArenaSector.SOUTHWEST;
-				boolean eUnsafeFromS = southFacing == ArenaSector.NORTHWEST || southFacing == ArenaSector.NORTHEAST || southFacing == ArenaSector.SOUTHEAST;
-				boolean wUnsafeFromE = eastFacing == ArenaSector.NORTH || eastFacing == ArenaSector.WEST || eastFacing == ArenaSector.SOUTH;
-				boolean eUnsafeFromW = westFacing == ArenaSector.NORTH || westFacing == ArenaSector.EAST || westFacing == ArenaSector.SOUTH;
-				boolean wSafe = (!wUnsafeFromS && !wUnsafeFromE);
-				boolean eSafe = (!eUnsafeFromS && !eUnsafeFromW);
+				List<UptimeExaflareMovement> safeSpots = new ArrayList<>(getPriority().get());
+				// Remove things that S will hit
+				if (willExaHitDirection(ArenaSector.NORTHWEST, southFacing)) {
+					safeSpots.remove(UptimeExaflareMovement.NORTHWEST_PLANT);
+				}
+				if (willExaHitDirection(ArenaSector.NORTHEAST, southFacing)) {
+					safeSpots.remove(UptimeExaflareMovement.NORTHEAST_PLANT);
+				}
+				if (willExaHitDirection(ArenaSector.NORTH, southFacing)) {
+					safeSpots.remove(UptimeExaflareMovement.SOUTH_NORTH);
+				}
+				// Remove things that NW will hit
+				if (willExaHitDirection(ArenaSector.EAST, westFacing)) {
+					safeSpots.remove(UptimeExaflareMovement.NORTHEAST_PLANT);
+				}
+				if (willExaHitDirection(ArenaSector.SOUTHEAST, westFacing)) {
+					safeSpots.remove(UptimeExaflareMovement.SOUTH_PLANT);
+					safeSpots.remove(UptimeExaflareMovement.SOUTH_EAST);
+				}
+				// Remove things that NE will hit
+				if (willExaHitDirection(ArenaSector.WEST, eastFacing)) {
+					safeSpots.remove(UptimeExaflareMovement.NORTHWEST_PLANT);
+				}
+				if (willExaHitDirection(ArenaSector.SOUTHWEST, eastFacing)) {
+					safeSpots.remove(UptimeExaflareMovement.SOUTH_PLANT);
+					safeSpots.remove(UptimeExaflareMovement.SOUTH_WEST);
+				}
 
-				ModifiableCallout<AbilityCastStart> call;
-				if (sUnsafeFromW && sUnsafeFromE) {
-					if (nUnsafeFromS) {
-						// bad pattern, can't uptime with this strat
-						if (wSafe) {
-							call = northwestPlant;
-						}
-						else if (eSafe) {
-							call = northeastPlant;
-						}
-						else {
-							call = badPattern;
-						}
-					}
-					else {
-						// south then north
-						call = southNorth;
-					}
+				log.info("Computed safe strats: {}", safeSpots);
+				final ModifiableCallout<AbilityCastStart> call;
+				if (safeSpots.isEmpty()) {
+					// Should never happen, just in case
+					call = badPattern;
 				}
 				else {
-					if (!sUnsafeFromW && !sUnsafeFromE) {
-						// Neither NW nor NE will hit S, so just dodge in and plant.
-						call = southPlant;
-					}
-					else {
-						if (sUnsafeFromW) {
-							// South then slightly west
-							call = southWest;
-						}
-						else {
-							// South then slightly east
-							call = southEast;
-						}
-					}
+					call = switch (safeSpots.get(0)) {
+						case SOUTH_PLANT -> southPlant;
+						case SOUTH_NORTH -> southNorth;
+						case SOUTH_WEST -> southWest;
+						case SOUTH_EAST -> southEast;
+						case NORTHWEST_PLANT -> northwestPlant;
+						case NORTHEAST_PLANT -> northeastPlant;
+						case DOWNTIME -> badPattern;
+					};
 				}
-				s.accept(call.getModified(realThordanCast));
-
-				// If card/intercard - dodge into south exa, then to the side of inter
-				// If card/card - sit in south
-				// If ic/ic - dodge into south exa, then to north side of hitbox
+				s.updateCall(call.getModified(realThordanCast));
 			}
 	);
 

--- a/triggers/src/main/java/gg/xp/xivsupport/events/triggers/duties/ewult/UptimeExaflareGui.java
+++ b/triggers/src/main/java/gg/xp/xivsupport/events/triggers/duties/ewult/UptimeExaflareGui.java
@@ -1,0 +1,45 @@
+package gg.xp.xivsupport.events.triggers.duties.ewult;
+
+import gg.xp.reevent.scan.ScanMe;
+import gg.xp.xivdata.data.duties.*;
+import gg.xp.xivsupport.gui.TitleBorderFullsizePanel;
+import gg.xp.xivsupport.gui.components.RearrangeableEnumListSetting;
+import gg.xp.xivsupport.gui.components.RearrangeableList;
+import gg.xp.xivsupport.gui.extra.DutyPluginTab;
+import gg.xp.xivsupport.gui.lists.FriendlyNameListCellRenderer;
+import gg.xp.xivsupport.gui.util.GuiUtil;
+import gg.xp.xivsupport.persistence.gui.BooleanSettingGui;
+
+import javax.swing.*;
+import java.awt.*;
+
+@ScanMe
+public class UptimeExaflareGui implements DutyPluginTab {
+
+	private final DragonsongUptimeExas backend;
+
+	public UptimeExaflareGui(DragonsongUptimeExas backend) {
+		this.backend = backend;
+	}
+
+	@Override
+	public String getTabName() {
+		return "Uptime Exaflares";
+	}
+
+	@Override
+	public Component getTabContents() {
+		TitleBorderFullsizePanel panel = new TitleBorderFullsizePanel("Uptime Exaflares");
+		JCheckBox cb = new BooleanSettingGui(backend.getCalloutGroupEnabledSetting(), "Enabled", true).getComponent();
+		RearrangeableList<UptimeExaflareMovement> listGui = new RearrangeableEnumListSetting<>(backend.getPriority()).getListGui();
+		listGui.setCellRenderer(new FriendlyNameListCellRenderer());
+		JLabel label = GuiUtil.labelFor("Priority (drag and drop to rearrange):", listGui);
+		GuiUtil.simpleTopDownLayout(panel, cb, Box.createVerticalStrut(10), label, listGui);
+		return panel;
+	}
+
+	@Override
+	public KnownDuty getDuty() {
+		return KnownDuty.Dragonsong;
+	}
+}

--- a/triggers/src/main/java/gg/xp/xivsupport/events/triggers/duties/ewult/UptimeExaflareMovement.java
+++ b/triggers/src/main/java/gg/xp/xivsupport/events/triggers/duties/ewult/UptimeExaflareMovement.java
@@ -1,0 +1,31 @@
+package gg.xp.xivsupport.events.triggers.duties.ewult;
+
+import gg.xp.xivsupport.gui.util.HasFriendlyName;
+
+import java.util.Arrays;
+import java.util.List;
+
+public enum UptimeExaflareMovement implements HasFriendlyName {
+	SOUTH_PLANT("South Plant"),
+	SOUTH_NORTH("South, Dodge North"),
+	SOUTH_WEST("South, Dodge Southwest"),
+	SOUTH_EAST("South, Dodge Southeast"),
+	NORTHWEST_PLANT("Northwest Plant"),
+	NORTHEAST_PLANT("Northeast Plant"),
+	DOWNTIME("Downtime (South, Dodge South)");
+
+	private final String friendlyName;
+
+	UptimeExaflareMovement(String friendlyName) {
+		this.friendlyName = friendlyName;
+	}
+
+	public static List<UptimeExaflareMovement> defaultOrder() {
+		return Arrays.asList(values());
+	}
+
+	@Override
+	public String getFriendlyName() {
+		return friendlyName;
+	}
+}

--- a/triggers/src/main/java/gg/xp/xivsupport/events/triggers/duties/ewult/UptimeExaflareMovement.java
+++ b/triggers/src/main/java/gg/xp/xivsupport/events/triggers/duties/ewult/UptimeExaflareMovement.java
@@ -7,11 +7,12 @@ import java.util.List;
 
 public enum UptimeExaflareMovement implements HasFriendlyName {
 	SOUTH_PLANT("South Plant"),
-	SOUTH_NORTH("South, Dodge North"),
 	SOUTH_WEST("South, Dodge Southwest"),
 	SOUTH_EAST("South, Dodge Southeast"),
+	SOUTH_NORTH("South, Dodge North (Wide Safe Spot)"),
 	NORTHWEST_PLANT("Northwest Plant"),
 	NORTHEAST_PLANT("Northeast Plant"),
+	SOUTH_NORTH_NARROW("South, Dodge North (Narrow Safe Spot)"),
 	DOWNTIME("Downtime (South, Dodge South)");
 
 	private final String friendlyName;

--- a/xivsupport/src/main/java/gg/xp/xivsupport/gui/map/MapDataController.java
+++ b/xivsupport/src/main/java/gg/xp/xivsupport/gui/map/MapDataController.java
@@ -170,7 +170,7 @@ public class MapDataController {
 			live = false;
 		}
 		index = newIndex;
-		log.info("setRelativeIndexAutoLive({}) => {}", delta, newIndex);
+		log.trace("setRelativeIndexAutoLive({}) => {}", delta, newIndex);
 		callback.run();
 	}
 


### PR DESCRIPTION
Customizable uptime exaflares. Probably will not merge until me or someone else has time to test extensively.

Current uptime exaflares is the prefer-south strat, where you always dodge into the south exaflare first unless it is impossible to maintain uptime, at which point it will tell you to plant in the safe exaflare instead. This PR gives you a customizable priority list, allowing you to pick your own preferences in terms of which movement it will call out if there is more than one possible solution (e.g. you can prioritize NW and NE plants over S non-plant).