### PR TITLE
Added option to show application delay on dot bars

### DIFF
--- a/plugins/dot-tracker/src/main/java/gg/xp/xivsupport/events/triggers/jobs/DotRefreshReminderGui.java
+++ b/plugins/dot-tracker/src/main/java/gg/xp/xivsupport/events/triggers/jobs/DotRefreshReminderGui.java
@@ -49,6 +49,7 @@ public class DotRefreshReminderGui implements PluginTab {
 		BooleanSetting enableTtsSetting = backend.getEnableTts();
 		BooleanSetting enableOverlaySetting = overlay.getEnabled();
 		BooleanSetting showTicksSetting = overlay.showTicks();
+		BooleanSetting showAppDelaySetting = overlay.showAppDelay();
 
 		JPanel settingsPanel = new JPanel();
 		settingsPanel.setLayout(new WrapLayout());
@@ -74,6 +75,11 @@ public class DotRefreshReminderGui implements PluginTab {
 		{
 			JCheckBox showTicks = new BooleanSettingGui(showTicksSetting, "Show Ticks", enableOverlaySetting::get).getComponent();
 			settingsPanel.add(showTicks);
+			showTicksSetting.addListener(outerPanel::repaint);
+		}
+		{
+			JCheckBox showAppDelay = new BooleanSettingGui(showAppDelaySetting, "Show Application Delay", enableOverlaySetting::get).getComponent();
+			settingsPanel.add(showAppDelay);
 			showTicksSetting.addListener(outerPanel::repaint);
 		}
 		{

--- a/plugins/dot-tracker/src/main/java/gg/xp/xivsupport/events/triggers/jobs/gui/DotBarRenderer.java
+++ b/plugins/dot-tracker/src/main/java/gg/xp/xivsupport/events/triggers/jobs/gui/DotBarRenderer.java
@@ -8,6 +8,7 @@ import gg.xp.xivsupport.gui.tables.renderers.TickRenderInfo;
 import org.jetbrains.annotations.NotNull;
 
 import java.awt.*;
+import java.time.Duration;
 import java.time.Instant;
 
 public class DotBarRenderer extends ResourceBarRenderer<VisualDotInfo> {
@@ -27,7 +28,7 @@ public class DotBarRenderer extends ResourceBarRenderer<VisualDotInfo> {
 		TickInfo tick = item.getTick();
 		BuffApplied event = item.getEvent();
 		if (tick == null || event.isPreApp()) {
-			bar.setTicks(null);
+			bar.setBottomTicks(null);
 		}
 		else {
 			Instant dotAppliedAt = event.getHappenedAt();
@@ -35,7 +36,16 @@ public class DotBarRenderer extends ResourceBarRenderer<VisualDotInfo> {
 			int interval = tick.getIntervalMs();
 			double normalizedInterval = ((double) interval) / duration;
 			double offset = ((double) tick.getMsToNextTick(dotAppliedAt)) / duration;
-			bar.setTicks(new TickRenderInfo(offset, normalizedInterval));
+			bar.setBottomTicks(new TickRenderInfo(offset, normalizedInterval));
+		}
+		Duration applicationDelay = item.getAppDelay();
+		if (applicationDelay == null || event.isPreApp()) {
+			bar.setTopTicks(null);
+		}
+		else {
+			long duration = event.getInitialDuration().toMillis();
+			long delay = applicationDelay.toMillis();
+			bar.setTopTicks(new TickRenderInfo( 1.0 - (delay / (double) duration), 1.0f));
 		}
 	}
 

--- a/plugins/dot-tracker/src/main/java/gg/xp/xivsupport/events/triggers/jobs/gui/DotTrackerOverlay.java
+++ b/plugins/dot-tracker/src/main/java/gg/xp/xivsupport/events/triggers/jobs/gui/DotTrackerOverlay.java
@@ -151,7 +151,7 @@ public class DotTrackerOverlay extends XivOverlay {
 							BuffApplied first = v.get(0);
 							if (v.size() == 1) {
 								Duration appDelay = showAppDelay.get() ? first.getDelay() : null;
-								if (appDelay != null && appDelay.toMillis() < 10) {
+								if (appDelay != null && appDelay.toMillis() < 75) {
 									appDelay = null;
 								}
 								if (first.getTarget().isThePlayer()) {

--- a/plugins/dot-tracker/src/main/java/gg/xp/xivsupport/events/triggers/jobs/gui/VisualDotInfo.java
+++ b/plugins/dot-tracker/src/main/java/gg/xp/xivsupport/events/triggers/jobs/gui/VisualDotInfo.java
@@ -5,16 +5,20 @@ import gg.xp.xivsupport.events.state.combatstate.TickInfo;
 import gg.xp.xivsupport.models.CurrentMaxPair;
 import org.jetbrains.annotations.Nullable;
 
+import java.time.Duration;
+
 public class VisualDotInfo implements CurrentMaxPair, LabelOverride {
 
 	private final BuffApplied buff;
 	private final String labelOverride;
 	private final @Nullable TickInfo tick;
+	private final @Nullable Duration appDelay;
 
-	public VisualDotInfo(BuffApplied buff, String labelOverride, @Nullable TickInfo tick) {
+	public VisualDotInfo(BuffApplied buff, String labelOverride, @Nullable TickInfo tick, @Nullable Duration appDelay) {
 		this.buff = buff;
 		this.labelOverride = labelOverride;
 		this.tick = tick;
+		this.appDelay = appDelay;
 	}
 
 	public BuffApplied getEvent() {
@@ -44,5 +48,9 @@ public class VisualDotInfo implements CurrentMaxPair, LabelOverride {
 
 	public @Nullable TickInfo getTick() {
 		return tick;
+	}
+
+	public @Nullable Duration getAppDelay() {
+		return appDelay;
 	}
 }

--- a/xivsupport/src/main/java/gg/xp/xivsupport/events/actlines/events/AbilityResolvedEvent.java
+++ b/xivsupport/src/main/java/gg/xp/xivsupport/events/actlines/events/AbilityResolvedEvent.java
@@ -4,14 +4,16 @@ import gg.xp.reevent.events.BaseEvent;
 import gg.xp.xivsupport.events.actlines.events.abilityeffect.AbilityEffect;
 import gg.xp.xivsupport.models.XivAbility;
 import gg.xp.xivsupport.models.XivCombatant;
+import org.jetbrains.annotations.Nullable;
 
 import java.io.Serial;
+import java.time.Instant;
 import java.util.List;
 
 /**
  * Represents an ability actual taking effect (as opposed to snapshotting)
  */
-public class AbilityResolvedEvent extends BaseEvent implements HasSourceEntity, HasTargetEntity, HasAbility, HasEffects, HasTargetIndex {
+public class AbilityResolvedEvent extends BaseEvent implements HasSourceEntity, HasTargetEntity, HasAbility, HasEffects, HasTargetIndex, HasOptionalDelay {
 	@Serial
 	private static final long serialVersionUID = 4043588325843768440L;
 	private final AbilityUsedEvent originalEvent;
@@ -65,5 +67,10 @@ public class AbilityResolvedEvent extends BaseEvent implements HasSourceEntity, 
 	@Override
 	public long getNumberOfTargets() {
 		return originalEvent.getNumberOfTargets();
+	}
+
+	@Override
+	public @Nullable Instant getPrecursorHappenedAt() {
+		return originalEvent.getEffectiveHappenedAt();
 	}
 }

--- a/xivsupport/src/main/java/gg/xp/xivsupport/events/actlines/events/HasOptionalDelay.java
+++ b/xivsupport/src/main/java/gg/xp/xivsupport/events/actlines/events/HasOptionalDelay.java
@@ -1,0 +1,22 @@
+package gg.xp.xivsupport.events.actlines.events;
+
+import org.jetbrains.annotations.Nullable;
+
+import java.time.Duration;
+import java.time.Instant;
+
+public interface HasOptionalDelay {
+
+	Instant getEffectiveHappenedAt();
+
+	@Nullable Instant getPrecursorHappenedAt();
+
+	default @Nullable Duration getDelay() {
+		Instant pre = getPrecursorHappenedAt();
+		if (pre == null) {
+			return null;
+		}
+		return Duration.between(pre, getEffectiveHappenedAt());
+	}
+
+}

--- a/xivsupport/src/main/java/gg/xp/xivsupport/events/state/combatstate/StatusEffectRepository.java
+++ b/xivsupport/src/main/java/gg/xp/xivsupport/events/state/combatstate/StatusEffectRepository.java
@@ -88,7 +88,7 @@ public class StatusEffectRepository {
 			);
 			BuffApplied preapp = preApps.remove(key);
 			if (preapp != null) {
-				event.setPreAppInfo(preapp.getPreAppInfo());
+				event.setPreAppInfo(preapp.getPreAppAbility(), preapp.getPreAppInfo());
 			}
 			onTargetCache.computeIfAbsent(target, k -> new LinkedHashMap<>()).put(key, event);
 		}

--- a/xivsupport/src/main/java/gg/xp/xivsupport/gui/tables/renderers/ResourceBar.java
+++ b/xivsupport/src/main/java/gg/xp/xivsupport/gui/tables/renderers/ResourceBar.java
@@ -19,7 +19,8 @@ public class ResourceBar extends JComponent {
 	private double percent1;
 	private double percent2;
 	private String[] textOptions;
-	private @Nullable TickRenderInfo ticks;
+	private @Nullable TickRenderInfo bottomTicks;
+	private @Nullable TickRenderInfo topTicks;
 
 	public ResourceBar() {
 		setTextOptions("");
@@ -125,26 +126,42 @@ public class ResourceBar extends JComponent {
 			g.fillRect(width1 + width2 + borderWidth, borderWidth, width3 + borderWidth, innerHeight);
 		}
 
-		if (borderColor != null) {
-			g.setColor(borderColor);
-			g.drawRect(0, 0, realWidth - 1, realHeight - 1);
-		}
-
-		if (ticks != null) {
+		if (bottomTicks != null) {
 			if (tickColor == null) {
 				g.setColor(label.getForeground());
 			}
 			else {
 				g.setColor(tickColor);
 			}
-			double current = ticks.offset();
+			double current = bottomTicks.offset();
 			while (current < 1.0d) {
 				int x = (int) (borderWidth + innerWidth * current);
 				int top = (int) ((4.0d * realHeight / 5.0d) - borderWidth);
-				int height = realHeight - top - 1;
+				int height = realHeight - top - borderWidth;
 				g.fillRect(x, top, 3, height);
-				current += ticks.interval();
+				current += bottomTicks.interval();
 			}
+		}
+		if (topTicks != null) {
+			if (tickColor == null) {
+				g.setColor(label.getForeground());
+			}
+			else {
+				g.setColor(tickColor);
+			}
+			double current = topTicks.offset();
+			while (current < 1.0d) {
+				int x = (int) (borderWidth + innerWidth * current);
+				int height = (int) ((1.0d * realHeight / 5.0d));
+				int top = borderWidth;
+				g.fillRect(x, top, 3, height);
+				current += topTicks.interval();
+			}
+		}
+
+		if (borderColor != null) {
+			g.setColor(borderColor);
+			g.drawRect(0, 0, realWidth - 1, realHeight - 1);
 		}
 
 		g.setTransform(old);
@@ -154,7 +171,11 @@ public class ResourceBar extends JComponent {
 		this.label.setForeground(textColor);
 	}
 
-	public void setTicks(@Nullable TickRenderInfo ticks) {
-		this.ticks = ticks;
+	public void setBottomTicks(@Nullable TickRenderInfo bottomTicks) {
+		this.bottomTicks = bottomTicks;
+	}
+
+	public void setTopTicks(@Nullable TickRenderInfo topTicks) {
+		this.topTicks = topTicks;
 	}
 }


### PR DESCRIPTION
Adds a tick mark in the top-right corner of a DoT bar to indicate the application delay for re-applying the DoT.