### PR TITLE
Support for groovy startup scripts + binding injection

### DIFF
--- a/xivsupport/src/main/java/gg/xp/xivsupport/groovy/GroovyScriptManager.java
+++ b/xivsupport/src/main/java/gg/xp/xivsupport/groovy/GroovyScriptManager.java
@@ -2,12 +2,16 @@ package gg.xp.xivsupport.groovy;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import gg.xp.reevent.events.EventContext;
+import gg.xp.reevent.events.InitEvent;
+import gg.xp.reevent.scan.HandleEvents;
 import gg.xp.reevent.scan.ScanMe;
 import gg.xp.xivsupport.gui.groovy.GroovyScriptHolder;
 import gg.xp.xivsupport.gui.groovy.ScriptNameAndFileStub;
 import gg.xp.xivsupport.gui.tables.filters.ValidationError;
 import gg.xp.xivsupport.persistence.Platform;
 import gg.xp.xivsupport.persistence.settings.ExternalObservable;
+import groovy.transform.builder.InitializerStrategy;
 import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -86,6 +90,16 @@ public class GroovyScriptManager {
 			}).filter(Objects::nonNull).forEachOrdered(this::addScript);
 		}
 		obs.notifyListeners();
+	}
+
+
+	@HandleEvents
+	public void runStartupScripts(EventContext context, InitEvent init) {
+		scripts.forEach(script -> {
+			if (script.isStartup()) {
+				script.run();
+			}
+		});
 	}
 
 	public void reloadAll() {

--- a/xivsupport/src/main/java/gg/xp/xivsupport/groovy/SubBinding.java
+++ b/xivsupport/src/main/java/gg/xp/xivsupport/groovy/SubBinding.java
@@ -1,0 +1,49 @@
+package gg.xp.xivsupport.groovy;
+
+import groovy.lang.Binding;
+import groovy.lang.MissingPropertyException;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public class SubBinding extends Binding {
+
+	private final Binding parent;
+
+	public SubBinding(Binding parent) {
+		this.parent = parent;
+	}
+
+	@Override
+	public Object getVariable(String name) {
+		if (super.hasVariable(name)) {
+			return super.getVariable(name);
+		}
+		else {
+			return parent.getVariable(name);
+		}
+	}
+
+	@Override
+	public boolean hasVariable(String name) {
+		return super.hasVariable(name) || parent.hasVariable(name);
+	}
+
+	@SuppressWarnings({"unchecked", "rawtypes"})
+	@Override
+	public Map getVariables() {
+		Map out = new LinkedHashMap(parent.getVariables());
+		out.putAll(super.getVariables());
+		return out;
+	}
+
+	@Override
+	public Object getProperty(String property) {
+		try {
+			return super.getProperty(property);
+		}
+		catch (MissingPropertyException e) {
+			return parent.getProperty(property);
+		}
+	}
+}

--- a/xivsupport/src/main/java/gg/xp/xivsupport/gui/groovy/GroovyPanel.java
+++ b/xivsupport/src/main/java/gg/xp/xivsupport/gui/groovy/GroovyPanel.java
@@ -8,6 +8,7 @@ import gg.xp.xivsupport.gui.tables.CustomColumn;
 import gg.xp.xivsupport.gui.tables.CustomTableModel;
 import gg.xp.xivsupport.gui.tabs.GroovyTab;
 import gg.xp.xivsupport.gui.util.EasyAction;
+import gg.xp.xivsupport.persistence.gui.BoundCheckbox;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -122,6 +123,11 @@ public class GroovyPanel extends JPanel {
 				JButton runButton = run.asButtonWithKeyLabel();
 				JPanel buttonHolder = new JPanel(new WrapLayout(WrapLayout.LEFT));
 				buttonHolder.add(runButton);
+				BoundCheckbox startupCb = new BoundCheckbox("Run on Startup", script::isStartup, startup -> {
+					script.setStartup(startup);
+					script.save();
+				});
+				buttonHolder.add(startupCb);
 				top.add(buttonHolder, BorderLayout.SOUTH);
 //				runButton.addActionListener(l -> submit());
 			}
@@ -192,6 +198,7 @@ public class GroovyPanel extends JPanel {
 	}
 
 	private void openExt() {
+		script.save();
 		try {
 			Desktop.getDesktop().open(script.getFile());
 		}

--- a/xivsupport/src/main/java/gg/xp/xivsupport/gui/groovy/GroovyScriptHolder.java
+++ b/xivsupport/src/main/java/gg/xp/xivsupport/gui/groovy/GroovyScriptHolder.java
@@ -26,6 +26,7 @@ public class GroovyScriptHolder {
 	private String scriptName;
 	private String scriptContent;
 	private boolean strict;
+	private boolean startup;
 	private boolean dirty;
 	@Nullable
 	private File file;
@@ -111,6 +112,7 @@ public class GroovyScriptHolder {
 	@JsonProperty("scriptName")
 	public void setScriptName(String scriptName) {
 		this.scriptName = scriptName;
+		dirty = true;
 	}
 
 	public String getScriptContent() {
@@ -133,7 +135,21 @@ public class GroovyScriptHolder {
 	@JsonProperty("strict")
 	public void setStrict(boolean strict) {
 		this.strict = strict;
+		dirty = true;
 	}
+
+	@JsonProperty("startup")
+	public boolean isStartup() {
+		return startup;
+	}
+
+	@JsonProperty("startup")
+	public void setStartup(boolean startup) {
+		this.startup = startup;
+		dirty = true;
+	}
+
+
 
 	public @Nullable File getFile() {
 		return file;


### PR DESCRIPTION
You can enable the "Run on Startup" box to have a script run on startup:

![image](https://user-images.githubusercontent.com/14287379/207946274-eca0cd35-b355-44e7-9168-1f94dd01d75e.png)


In addition, there is now a "globals" object which allows you to manipulate the global groovy binding. This allows you to access them in other places, such as the events tab:

![image](https://user-images.githubusercontent.com/14287379/207946328-ffa47f04-6a3d-4f13-882b-bb121307e28d.png)

You can use this to make whatever custom queries you want.