### PR TITLE
CD tracker for custom party list

### DIFF
--- a/.idea/runConfigurations/gg_xp_xivsupport_gui_GuiWithTestData.xml
+++ b/.idea/runConfigurations/gg_xp_xivsupport_gui_GuiWithTestData.xml
@@ -1,7 +1,10 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="gg.xp.xivsupport.gui.GuiWithTestData" type="Application" factoryName="Application" nameIsGenerated="true">
+    <envs>
+      <env name="TRIGGEVENT_TESTING" value="true" />
+    </envs>
     <option name="MAIN_CLASS_NAME" value="gg.xp.xivsupport.gui.GuiWithTestData" />
-    <module name="xivsupport" />
+    <module name="launcher" />
     <extension name="coverage">
       <pattern>
         <option name="PATTERN" value="gg.xp.xivsupport.gui.imprt.*" />

--- a/plugins/cd-tracker/src/main/java/gg/xp/xivsupport/events/state/combatstate/CooldownHelper.java
+++ b/plugins/cd-tracker/src/main/java/gg/xp/xivsupport/events/state/combatstate/CooldownHelper.java
@@ -10,6 +10,7 @@ import gg.xp.xivsupport.events.state.XivState;
 import gg.xp.xivsupport.models.CdTrackingKey;
 import gg.xp.xivsupport.models.CombatantType;
 import gg.xp.xivsupport.models.XivCombatant;
+import gg.xp.xivsupport.models.XivPlayerCharacter;
 import org.jetbrains.annotations.Nullable;
 
 import java.time.Instant;
@@ -76,5 +77,12 @@ public class CooldownHelper {
 
 	public @Nullable CooldownStatus getPersonalCd(Cooldown cd) {
 		return getCooldowns(XivCombatant::isThePlayer, cd::equals).stream().findFirst().orElse(null);
+	}
+
+	public @Nullable CooldownStatus getCdStatusForPlayer(XivPlayerCharacter player, ExtendedCooldownDescriptor ecd) {
+		return getCooldowns(source -> source.equals(player), cd -> cd.equals(ecd))
+				.stream()
+				.findFirst()
+				.orElse(null);
 	}
 }

--- a/plugins/cd-tracker/src/main/java/gg/xp/xivsupport/events/triggers/jobs/gui/BaseCdTrackerOverlay.java
+++ b/plugins/cd-tracker/src/main/java/gg/xp/xivsupport/events/triggers/jobs/gui/BaseCdTrackerOverlay.java
@@ -33,26 +33,21 @@ public abstract class BaseCdTrackerOverlay extends XivOverlay {
 //	private volatile List<BuffApplied> currentBuffs = Collections.emptyList();
 	private volatile List<CooldownStatus> currentCds;
 
-	private final ColorSetting activeColor;
-	private final ColorSetting readyColor;
-	private final ColorSetting onCdColor;
-	private final ColorSetting preappColor;
-	private final ColorSetting fontColor;
-
 	protected BaseCdTrackerOverlay(String title, String settingKeyBase, OverlayConfig oc, PersistenceProvider persistence, IntSetting rowSetting) {
 		super(title, settingKeyBase, oc, persistence);
 		numberOfRows = rowSetting;
 		numberOfRows.addListener(this::repackSize);
 
 		CdColorProvider defaults = DefaultCdTrackerColorProvider.INSTANCE;
-		activeColor = new ColorSetting(persistence, settingKeyBase + ".active-color", defaults.getActiveColor());
-		readyColor = new ColorSetting(persistence, settingKeyBase + ".ready-color", defaults.getReadyColor());
-		onCdColor = new ColorSetting(persistence, settingKeyBase + ".oncd-color", defaults.getOnCdColor());
-		preappColor = new ColorSetting(persistence, settingKeyBase + ".preapp-color", defaults.getPreappColor());
-		fontColor = new ColorSetting(persistence, settingKeyBase + ".font-color", defaults.getFontColor());
+//		ColorSetting activeColor = new ColorSetting(persistence, settingKeyBase + ".active-color", defaults.getActiveColor());
+//		ColorSetting readyColor = new ColorSetting(persistence, settingKeyBase + ".ready-color", defaults.getReadyColor());
+//		ColorSetting onCdColor = new ColorSetting(persistence, settingKeyBase + ".oncd-color", defaults.getOnCdColor());
+//		ColorSetting preappColor = new ColorSetting(persistence, settingKeyBase + ".preapp-color", defaults.getPreappColor());
+//		ColorSetting fontColor = new ColorSetting(persistence, settingKeyBase + ".font-color", defaults.getFontColor());
 		onlyActive = new BooleanSetting(persistence, settingKeyBase + ".only-show-active", false);
 
-		colors = new SettingsCdTrackerColorProvider(activeColor, readyColor, onCdColor, preappColor, fontColor);
+		colors = SettingsCdTrackerColorProvider.of(persistence, settingKeyBase, defaults);
+//		colors = new SettingsCdTrackerColorProvider(activeColor, readyColor, onCdColor, preappColor, fontColor);
 		BaseCdTrackerTable tableHolder = new BaseCdTrackerTable(() -> croppedCds, colors);
 		tableModel = tableHolder.getTableModel();
 		table = tableHolder.getTable();

--- a/plugins/cd-tracker/src/main/java/gg/xp/xivsupport/events/triggers/jobs/gui/SettingsCdTrackerColorProvider.java
+++ b/plugins/cd-tracker/src/main/java/gg/xp/xivsupport/events/triggers/jobs/gui/SettingsCdTrackerColorProvider.java
@@ -1,5 +1,7 @@
 package gg.xp.xivsupport.events.triggers.jobs.gui;
 
+import gg.xp.xivsupport.persistence.PersistenceProvider;
+import gg.xp.xivsupport.persistence.settings.BooleanSetting;
 import gg.xp.xivsupport.persistence.settings.ColorSetting;
 
 import java.awt.*;
@@ -63,6 +65,20 @@ public class SettingsCdTrackerColorProvider implements CdColorProvider {
 
 	public ColorSetting getFontSetting() {
 		return font;
+	}
+
+	public static SettingsCdTrackerColorProvider of(PersistenceProvider persistence, String settingKeyBase, CdColorProvider defaults) {
+		ColorSetting activeColor;
+		ColorSetting readyColor;
+		ColorSetting onCdColor;
+		ColorSetting preappColor;
+		ColorSetting fontColor;
+		activeColor = new ColorSetting(persistence, settingKeyBase + ".active-color", defaults.getActiveColor());
+		readyColor = new ColorSetting(persistence, settingKeyBase + ".ready-color", defaults.getReadyColor());
+		onCdColor = new ColorSetting(persistence, settingKeyBase + ".oncd-color", defaults.getOnCdColor());
+		preappColor = new ColorSetting(persistence, settingKeyBase + ".preapp-color", defaults.getPreappColor());
+		fontColor = new ColorSetting(persistence, settingKeyBase + ".font-color", defaults.getFontColor());
+		return new SettingsCdTrackerColorProvider(activeColor, readyColor, onCdColor, preappColor, fontColor);
 	}
 
 }

--- a/plugins/custom-party-overlay/pom.xml
+++ b/plugins/custom-party-overlay/pom.xml
@@ -17,6 +17,10 @@
             <groupId>gg.xp</groupId>
             <artifactId>xivsupport</artifactId>
         </dependency>
+        <dependency>
+            <groupId>gg.xp</groupId>
+            <artifactId>cd-tracker</artifactId>
+        </dependency>
     </dependencies>
 
 </project>

--- a/plugins/custom-party-overlay/src/main/java/gg/xp/xivsupport/custompartyoverlay/CustomPartyOverlay.java
+++ b/plugins/custom-party-overlay/src/main/java/gg/xp/xivsupport/custompartyoverlay/CustomPartyOverlay.java
@@ -51,8 +51,8 @@ public class CustomPartyOverlay extends XivOverlay {
 			}
 			if (existingItems.stream().noneMatch(spec -> spec.componentType == type)) {
 				getDefaults().stream().filter(defaultItem -> defaultItem.componentType == type)
-								.findFirst()
-										.ifPresent(newItems::add);
+						.findFirst()
+						.ifPresent(newItems::add);
 			}
 		}
 		newItems.forEach(elements::addItem);
@@ -117,17 +117,25 @@ public class CustomPartyOverlay extends XivOverlay {
 						continue;
 					}
 					Component component = ref.getComponent();
+					panel.add(component);
 					component.setBounds(spec.x, spec.y + offset, spec.width, spec.height);
 					maxX = Math.max(maxX, spec.x + spec.width);
 					maxY = Math.max(maxY, spec.y + offset + spec.height);
-					panel.add(component);
 					list.add(ref);
 					log.trace("Added: {} -> {} -> {}", i, spec.componentType, component);
 				}
 			}
 			panel.setPreferredSize(new Dimension(maxX + 10, maxY + 10));
 			this.refreshables = refreshables;
+			try {
+				panel.validate();
+			}
+			catch (Throwable t) {
+				log.error("Error validating!", t);
+			}
 			repackSize();
+			SwingUtilities.invokeLater(() -> {
+			});
 		});
 	}
 
@@ -195,6 +203,16 @@ public class CustomPartyOverlay extends XivOverlay {
 			comp.width = 60;
 			comp.height = 14;
 			comp.componentType = CustomPartyOverlayComponentType.MP_BAR;
+			specs.add(comp);
+		}
+		{
+			CustomOverlayComponentSpec comp = new CustomOverlayComponentSpec();
+			comp.x = 0;
+			comp.y = 0;
+			comp.width = 120;
+			comp.height = 40;
+			comp.enabled = false;
+			comp.componentType = CustomPartyOverlayComponentType.COOLDOWNS;
 			specs.add(comp);
 		}
 		return specs;

--- a/plugins/custom-party-overlay/src/main/java/gg/xp/xivsupport/custompartyoverlay/CustomPartyOverlayComponentType.java
+++ b/plugins/custom-party-overlay/src/main/java/gg/xp/xivsupport/custompartyoverlay/CustomPartyOverlayComponentType.java
@@ -1,11 +1,13 @@
 package gg.xp.xivsupport.custompartyoverlay;
 
 import gg.xp.xivsupport.custompartyoverlay.buffs.CustomBuffsBarComponentGui;
-import gg.xp.xivsupport.custompartyoverlay.buffs.NormalBuffsBarComponentGui;
 import gg.xp.xivsupport.custompartyoverlay.buffs.CustomBuffsBarPartyComponent;
+import gg.xp.xivsupport.custompartyoverlay.buffs.NormalBuffsBarComponentGui;
 import gg.xp.xivsupport.custompartyoverlay.buffs.NormalBuffsBarPartyComponent;
 import gg.xp.xivsupport.custompartyoverlay.castbar.CastBarComponentGui;
 import gg.xp.xivsupport.custompartyoverlay.castbar.CastBarPartyComponent;
+import gg.xp.xivsupport.custompartyoverlay.cdtracker.CustomPartyCdTrackerComponent;
+import gg.xp.xivsupport.custompartyoverlay.cdtracker.CustomPartyCdTrackerGui;
 import gg.xp.xivsupport.custompartyoverlay.hpbar.HpBarComponent;
 import gg.xp.xivsupport.custompartyoverlay.hpbar.HpBarComponentGui;
 import gg.xp.xivsupport.custompartyoverlay.mpbar.MpBarComponent;
@@ -30,7 +32,8 @@ public enum CustomPartyOverlayComponentType implements HasFriendlyName {
 	BUFFS_WITH_TIMERS("Buffs", NormalBuffsBarPartyComponent.class, NormalBuffsBarComponentGui.class),
 	CAST_BAR("Cast Bar", CastBarPartyComponent.class, CastBarComponentGui.class),
 	MP_BAR("MP Bar", MpBarComponent.class, MpBarComponentGui.class),
-	CUSTOM_BUFFS("Custom Buffs", CustomBuffsBarPartyComponent.class, CustomBuffsBarComponentGui.class);
+	CUSTOM_BUFFS("Custom Buffs", CustomBuffsBarPartyComponent.class, CustomBuffsBarComponentGui.class),
+	COOLDOWNS("Cooldown Icons", CustomPartyCdTrackerComponent.class, CustomPartyCdTrackerGui.class);
 
 	private final String friendlyName;
 	private final Class<? extends RefreshablePartyListComponent> componentClass;

--- a/plugins/custom-party-overlay/src/main/java/gg/xp/xivsupport/custompartyoverlay/cdtracker/CustomPartyCdSetting.java
+++ b/plugins/custom-party-overlay/src/main/java/gg/xp/xivsupport/custompartyoverlay/cdtracker/CustomPartyCdSetting.java
@@ -1,0 +1,20 @@
+package gg.xp.xivsupport.custompartyoverlay.cdtracker;
+
+import gg.xp.xivdata.data.*;
+import gg.xp.xivsupport.persistence.PersistenceProvider;
+import gg.xp.xivsupport.persistence.settings.BooleanSetting;
+
+import java.util.EnumSet;
+import java.util.Set;
+
+public class CustomPartyCdSetting {
+	private final BooleanSetting enable;
+
+	public CustomPartyCdSetting(PersistenceProvider persistence, String settingKeyBase, boolean enableByDefault) {
+		this.enable = new BooleanSetting(persistence, settingKeyBase + ".in-custom-party-overlay", enableByDefault);
+	}
+
+	public BooleanSetting getEnable() {
+		return enable;
+	}
+}

--- a/plugins/custom-party-overlay/src/main/java/gg/xp/xivsupport/custompartyoverlay/cdtracker/CustomPartyCdTrackerComponent.java
+++ b/plugins/custom-party-overlay/src/main/java/gg/xp/xivsupport/custompartyoverlay/cdtracker/CustomPartyCdTrackerComponent.java
@@ -1,0 +1,284 @@
+package gg.xp.xivsupport.custompartyoverlay.cdtracker;
+
+import gg.xp.xivdata.data.*;
+import gg.xp.xivsupport.custompartyoverlay.BasePartyListComponent;
+import gg.xp.xivsupport.events.state.combatstate.CooldownHelper;
+import gg.xp.xivsupport.events.state.combatstate.CooldownStatus;
+import gg.xp.xivsupport.events.triggers.jobs.gui.SettingsCdTrackerColorProvider;
+import gg.xp.xivsupport.events.triggers.jobs.gui.VisualCdInfo;
+import gg.xp.xivsupport.events.triggers.jobs.gui.VisualCdInfoMain;
+import gg.xp.xivsupport.gui.tables.renderers.IconTextRenderer;
+import gg.xp.xivsupport.gui.tables.renderers.ScaledImageComponent;
+import gg.xp.xivsupport.models.XivPlayerCharacter;
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.swing.*;
+import java.awt.*;
+import java.awt.geom.AffineTransform;
+import java.awt.geom.Rectangle2D;
+import java.awt.geom.RoundRectangle2D;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class CustomPartyCdTrackerComponent extends BasePartyListComponent {
+
+	private static final Logger log = LoggerFactory.getLogger(CustomPartyCdTrackerComponent.class);
+
+	private final CooldownHelper cdh;
+	private final CustomPartyCdTrackerConfig config;
+	private final Map<ExtendedCooldownDescriptor, CooldownDisplayComponent> components = new HashMap<>();
+	//	private final List<CooldownDisplayComponent> rawList = new ArrayList<>();
+	private List<ExtendedCooldownDescriptor> enabled;
+	private final JPanel panel = new JPanel(null) {
+		{
+			setLayout(null);
+		}
+
+		@Override
+		public void validate() {
+			super.validate();
+			int spacing = config.getSpacing().get();
+			boolean rtl = config.getRightToLeft().get();
+			int height = getHeight();
+			int width = getWidth();
+			Component[] comps = getComponents();
+			for (int i = 0; i < comps.length; i++) {
+				int xOffset = i * (height + spacing);
+				if ((xOffset + height) > width) {
+					// Trigger a re-read
+					forceReset();
+				}
+				int realX = rtl ? width - xOffset - height : xOffset;
+				comps[i].setBounds(realX, 0, height, height);
+			}
+		}
+
+		@Override
+		public void setBounds(int x, int y, int width, int height) {
+			super.setBounds(x, y, width, height);
+			validate();
+		}
+
+		@Override
+		public void paint(Graphics g) {
+			super.paint(g);
+		}
+	};
+
+	public CustomPartyCdTrackerComponent(CooldownHelper cdh, CustomPartyCdTrackerConfig config) {
+		this.cdh = cdh;
+		this.config = config;
+		resetEnabledCds();
+		panel.setOpaque(false);
+//		panel.setBackground(Color.ORANGE);
+		config.addListener(() -> SwingUtilities.invokeLater(panel::validate));
+		config.addListener(this::forceReset);
+	}
+
+	private int maxItems() {
+		return panel.getWidth() / (panel.getHeight() + config.getSpacing().get());
+	}
+
+	@Override
+	protected Component makeComponent() {
+		return panel;
+	}
+
+	private void resetEnabledCds() {
+		enabled = config.getEnabledCds();
+	}
+
+	private void forceReset() {
+		// dumb but works
+		resetEnabledCds();
+		lastJob = null;
+	}
+
+	private Job lastJob;
+
+	@Override
+	protected void reformatComponent(@NotNull XivPlayerCharacter xpc) {
+		if (panel.getParent() == null) {
+			// If we aren't visible yet, don't do anything
+			return;
+		}
+		// I don't know if this can happen, but better safe than sorry
+		Job job = xpc.getJob();
+		if (job == null) {
+			return;
+		}
+		JobType jobCat = job.getCategory();
+		if (job != lastJob) {
+			lastJob = job;
+//			rawList.clear();
+			components.clear();
+			SwingUtilities.invokeLater(panel::removeAll);
+		}
+//		Map<ExtendedCooldownDescriptor, VisualCdInfo> statusNew = new HashMap<>();
+		List<ExtendedCooldownDescriptor> enabled = this.enabled.stream()
+				.filter(extendedCooldownDescriptor ->
+						extendedCooldownDescriptor.getJob() == job
+								|| extendedCooldownDescriptor.getJobType() == jobCat
+								|| extendedCooldownDescriptor == Cooldown.Swiftcast
+								&& (jobCat == JobType.HEALER || jobCat == JobType.CASTER)
+								&& ActionLibrary.iconForId(extendedCooldownDescriptor.getPrimaryAbilityId()) != null)
+				.limit(maxItems())
+				.toList();
+		for (ExtendedCooldownDescriptor extendedCooldownDescriptor : enabled.subList(0, Math.min(enabled.size(), maxItems()))) {
+			CooldownStatus raw = cdh.getCdStatusForPlayer(xpc, extendedCooldownDescriptor);
+			VisualCdInfo vci;
+			if (raw == null) {
+				vci = new VisualCdInfoMain(extendedCooldownDescriptor);
+			}
+			else {
+				vci = new VisualCdInfoMain(raw);
+			}
+//			statusNew.put(extendedCooldownDescriptor, vci);
+			CooldownDisplayComponent disp = components.computeIfAbsent(extendedCooldownDescriptor, k -> {
+				CooldownDisplayComponent newComponent = new CooldownDisplayComponent(extendedCooldownDescriptor);
+//				rawList.add(newComponent);
+				SwingUtilities.invokeLater(() -> panel.add(newComponent));
+				return newComponent;
+			});
+			disp.setData(vci);
+		}
+		SwingUtilities.invokeLater(panel::validate);
+//		statuses = statusNew;
+	}
+
+	private final class CooldownDisplayComponent extends JPanel {
+		//		private final ExtendedCooldownDescriptor ecd;
+//		private VisualCdInfo cdi;
+		//		private AutoHeightScalingIcon icon;
+		private ScaledImageComponent icon;
+		private Color borderColor = Color.PINK;
+		private double fillPercent;
+
+		private CooldownDisplayComponent(ExtendedCooldownDescriptor ecd) {
+//			this.ecd = ecd;
+			setLayout(null);
+			ActionIcon icon = ActionLibrary.iconForId(ecd.getPrimaryAbilityId());
+			ScaledImageComponent scaleIcon = IconTextRenderer.getIconOnly(icon);
+			if (scaleIcon != null) {
+				this.icon = scaleIcon.cloneThis();
+			}
+
+//			ScaledImageComponent scaleIcon = IconTextRenderer.getIconOnly(icon);
+//			if (scaleIcon != null) {
+//				AutoHeightScalingIcon stretchyIcon = new AutoHeightScalingIcon(scaleIcon.cloneThis());
+//				add(stretchyIcon, BorderLayout.CENTER);
+//				this.icon = stretchyIcon;
+//			}
+
+			setBackground(Color.PINK);
+		}
+
+		@Override
+		public void validate() {
+			super.validate();
+			icon = icon.withNewSize(getHeight() - 2 * config.getBorderWidth().get());
+//			icon.setBounds(0, 0, getWidth(), getHeight());
+//			icon.invalidate();
+		}
+
+		@Override
+		public void setBounds(int x, int y, int width, int height) {
+			super.setBounds(x, y, width, height);
+			icon = icon.withNewSize(height - 2 * config.getBorderWidth().get());
+//			icon.setBounds(0, 0, width, height);
+//			icon.invalidate();
+		}
+
+		public void setData(VisualCdInfo cdi) {
+//			this.cdi = cdi;
+			SettingsCdTrackerColorProvider colors = config.getColors();
+			this.borderColor = switch (cdi.getStatus()) {
+				case READY, NOT_YET_USED -> colors.getReadyColor();
+				case BUFF_PREAPP -> colors.getPreappColor();
+				case BUFF_ACTIVE -> colors.getActiveColor();
+				case ON_COOLDOWN -> colors.getOnCdColor();
+			};
+			fillPercent = cdi.getPercent();
+
+//			setBorder(new LineBorder(borderColor, 4));
+		}
+
+		@Override
+		protected void paintComponent(Graphics g) {
+			Graphics2D g2d = (Graphics2D) g.create();
+			g2d.setColor(borderColor);
+			// Mostly copied from LineBorder
+			Shape outer;
+			int x = 0;
+			int y = 0;
+			int height = getHeight();
+			int width = getWidth();
+			int offs = config.getBorderRoundness().get();
+			if (offs > 0) {
+				outer = new RoundRectangle2D.Float(x, y, width, height, offs, offs);
+			}
+			else {
+				outer = new Rectangle2D.Float(x, y, width, height);
+			}
+
+
+//			double fillAmount = (System.currentTimeMillis() % 10_000) / 10_000.0;
+			double fillAmount = fillPercent;
+//			switch (cdi.getStatus()) {
+//
+//			}
+			// This is technically wrong since it is doing it linearly along the edge instead of radially
+			Polygon clipPoly;
+			if (fillAmount < 0.125) {
+				clipPoly = new Polygon(
+						new int[]{0, 0, (int) (width * (8 * fillAmount))},
+						new int[]{0, -height, -height},
+						3);
+			}
+			else if (fillAmount < 0.375) {
+				clipPoly = new Polygon(
+						new int[]{0, 0, width, width},
+						new int[]{0, -height, -height, (int) (height * 8.0 * (fillAmount - 0.25))},
+						4);
+			}
+			else if (fillAmount < 0.625) {
+				clipPoly = new Polygon(
+						new int[]{0, 0, width, width, (int) (-width * (8 * (fillAmount - 0.5)))},
+						new int[]{0, -height, -height, height, height},
+						5);
+			}
+			else if (fillAmount < 0.875) {
+				clipPoly = new Polygon(
+						new int[]{0, 0, width, width, -width, -width},
+						new int[]{0, -height, -height, height, height, (int) (-height * 8.0 * (fillAmount - 0.75))},
+						6);
+			}
+			else if (fillAmount < 1.0) {
+				clipPoly = new Polygon(
+						new int[]{0, 0, width, width, -width, -width, (int) (width * (8 * (fillAmount - 1.0)))},
+						new int[]{0, -height, -height, height, height, -height, -height},
+						7);
+			}
+			else {
+				clipPoly = null;
+			}
+			{
+				Graphics2D clipped = (Graphics2D) g2d.create();
+				if (clipPoly != null) {
+					clipPoly.translate(width / 2, height / 2);
+					clipped.clip(clipPoly);
+				}
+				clipped.fill(outer);
+			}
+			AffineTransform tf = g2d.getTransform();
+			int bw = config.getBorderWidth().get();
+			tf.translate(bw, bw);
+			g2d.setTransform(tf);
+			icon.paint(g2d);
+		}
+
+	}
+}

--- a/plugins/custom-party-overlay/src/main/java/gg/xp/xivsupport/custompartyoverlay/cdtracker/CustomPartyCdTrackerComponent.java
+++ b/plugins/custom-party-overlay/src/main/java/gg/xp/xivsupport/custompartyoverlay/cdtracker/CustomPartyCdTrackerComponent.java
@@ -280,6 +280,7 @@ public class CustomPartyCdTrackerComponent extends BasePartyListComponent {
 					clipPoly.translate(width / 2, height / 2);
 					clipped.clip(clipPoly);
 				}
+				clipped.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
 				clipped.fill(outer);
 			}
 			AffineTransform tf = g2d.getTransform();

--- a/plugins/custom-party-overlay/src/main/java/gg/xp/xivsupport/custompartyoverlay/cdtracker/CustomPartyCdTrackerComponent.java
+++ b/plugins/custom-party-overlay/src/main/java/gg/xp/xivsupport/custompartyoverlay/cdtracker/CustomPartyCdTrackerComponent.java
@@ -118,13 +118,22 @@ public class CustomPartyCdTrackerComponent extends BasePartyListComponent {
 			SwingUtilities.invokeLater(panel::removeAll);
 		}
 //		Map<ExtendedCooldownDescriptor, VisualCdInfo> statusNew = new HashMap<>();
+		boolean scOnlyRez = config.getScOnlyRez().get();
 		List<ExtendedCooldownDescriptor> enabled = this.enabled.stream()
-				.filter(extendedCooldownDescriptor ->
-						extendedCooldownDescriptor.getJob() == job
-								|| extendedCooldownDescriptor.getJobType() == jobCat
-								|| extendedCooldownDescriptor == Cooldown.Swiftcast
-								&& (jobCat == JobType.HEALER || jobCat == JobType.CASTER)
-								&& ActionLibrary.iconForId(extendedCooldownDescriptor.getPrimaryAbilityId()) != null)
+				.filter(extendedCooldownDescriptor -> {
+					if (extendedCooldownDescriptor == Cooldown.Swiftcast) {
+						if (scOnlyRez) {
+							return job.usesSwiftRez();
+						}
+						else {
+							return jobCat == JobType.HEALER || jobCat == JobType.CASTER;
+						}
+					}
+					else {
+						return extendedCooldownDescriptor.getJob() == job
+								|| extendedCooldownDescriptor.getJobType() == jobCat;
+					}
+				})
 				.limit(maxItems())
 				.toList();
 		for (ExtendedCooldownDescriptor extendedCooldownDescriptor : enabled.subList(0, Math.min(enabled.size(), maxItems()))) {

--- a/plugins/custom-party-overlay/src/main/java/gg/xp/xivsupport/custompartyoverlay/cdtracker/CustomPartyCdTrackerConfig.java
+++ b/plugins/custom-party-overlay/src/main/java/gg/xp/xivsupport/custompartyoverlay/cdtracker/CustomPartyCdTrackerConfig.java
@@ -42,6 +42,7 @@ public class CustomPartyCdTrackerConfig extends ObservableSetting {
 	private final IntSetting borderWidth;
 	private final IntSetting borderRoundness;
 	private final BooleanSetting rightToLeft;
+	private final BooleanSetting scOnlyRez;
 	private final SettingsCdTrackerColorProvider colors;
 
 	public CustomPartyCdTrackerConfig(CustomCooldownManager customCooldownManager, PersistenceProvider persistence) {
@@ -60,7 +61,8 @@ public class CustomPartyCdTrackerConfig extends ObservableSetting {
 		this.borderWidth = new IntSetting(persistence, settingKeyBase + ".border-width", 2, 1, 100);
 		this.borderRoundness = new IntSetting(persistence, settingKeyBase + ".border-roundness", 0, 0, 100);
 		this.rightToLeft = new BooleanSetting(persistence, settingKeyBase + ".right-to-left", true);
-		List.of(spacing, borderWidth, borderRoundness, rightToLeft)
+		this.scOnlyRez = new BooleanSetting(persistence, settingKeyBase + ".swiftcast-only-rez", true);
+		List.of(spacing, borderWidth, borderRoundness, rightToLeft, scOnlyRez)
 				.forEach(setting -> setting.addListener(this::notifyListeners));
 		refreshCustoms();
 	}
@@ -140,6 +142,10 @@ public class CustomPartyCdTrackerConfig extends ObservableSetting {
 		return borderWidth;
 	}
 
+	public BooleanSetting getScOnlyRez() {
+		return scOnlyRez;
+	}
+
 	@SuppressWarnings("SuspiciousMethodCalls")
 	private static boolean defaultSetting(ExtendedCooldownDescriptor ecd) {
 		return defaultEnabled.contains(ecd);
@@ -161,6 +167,7 @@ public class CustomPartyCdTrackerConfig extends ObservableSetting {
 			Cooldown.Mug,
 			Cooldown.ArcaneCircle,
 			Cooldown.Troubadour,
+			Cooldown.Tactician,
 			Cooldown.RadiantFinale,
 			Cooldown.TechnicalStep,
 			Cooldown.Devilment,

--- a/plugins/custom-party-overlay/src/main/java/gg/xp/xivsupport/custompartyoverlay/cdtracker/CustomPartyCdTrackerConfig.java
+++ b/plugins/custom-party-overlay/src/main/java/gg/xp/xivsupport/custompartyoverlay/cdtracker/CustomPartyCdTrackerConfig.java
@@ -1,0 +1,171 @@
+package gg.xp.xivsupport.custompartyoverlay.cdtracker;
+
+import gg.xp.reevent.events.EventContext;
+import gg.xp.reevent.scan.HandleEvents;
+import gg.xp.reevent.scan.ScanMe;
+import gg.xp.xivdata.data.*;
+import gg.xp.xivsupport.cdsupport.CustomCooldown;
+import gg.xp.xivsupport.cdsupport.CustomCooldownManager;
+import gg.xp.xivsupport.cdsupport.CustomCooldownsUpdated;
+import gg.xp.xivsupport.events.triggers.jobs.gui.DefaultCdTrackerColorProvider;
+import gg.xp.xivsupport.events.triggers.jobs.gui.SettingsCdTrackerColorProvider;
+import gg.xp.xivsupport.persistence.PersistenceProvider;
+import gg.xp.xivsupport.persistence.settings.BooleanSetting;
+import gg.xp.xivsupport.persistence.settings.IntSetting;
+import gg.xp.xivsupport.persistence.settings.ObservableSetting;
+import groovyjarjarantlr4.v4.runtime.misc.IntSet;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+@ScanMe
+public class CustomPartyCdTrackerConfig extends ObservableSetting {
+
+	private static final Logger log = LoggerFactory.getLogger(CustomPartyCdTrackerConfig.class);
+
+	//	private List<ExtendedCooldownDescriptor> allCds = Collections.emptyList();
+	private final Map<Cooldown, CustomPartyCdSetting> partyCdsBuiltin = new LinkedHashMap<>();
+	private final Map<ExtendedCooldownDescriptor, CustomPartyCdSetting> partyCdsCustom = new LinkedHashMap<>();
+	private Map<ExtendedCooldownDescriptor, CustomPartyCdSetting> partyCds = Collections.emptyMap();
+	private static final String settingKeyBase = "custom-party.cd-tracker";
+	private static final String cdKeyStub = settingKeyBase + ".enable-cd.";
+
+	private final CustomCooldownManager customCooldownManager;
+	private final PersistenceProvider persistence;
+	private final IntSetting spacing;
+	private final IntSetting borderWidth;
+	private final IntSetting borderRoundness;
+	private final BooleanSetting rightToLeft;
+	private final SettingsCdTrackerColorProvider colors;
+
+	public CustomPartyCdTrackerConfig(CustomCooldownManager customCooldownManager, PersistenceProvider persistence) {
+		for (Cooldown cd : Cooldown.values()) {
+			// Filter out invalid - we need an icon, and we can't do charge display (yet)
+			if (isValidCd(cd)) {
+				CustomPartyCdSetting newSetting = new CustomPartyCdSetting(persistence, getKey(cd) + ".party", defaultSetting(cd));
+				setupListener(newSetting);
+				partyCdsBuiltin.put(cd, newSetting);
+			}
+		}
+		this.customCooldownManager = customCooldownManager;
+		this.persistence = persistence;
+		this.colors = SettingsCdTrackerColorProvider.of(persistence, settingKeyBase + ".colors", DefaultCdTrackerColorProvider.INSTANCE);
+		this.spacing = new IntSetting(persistence, settingKeyBase + ".spacing", 2, 0, 1000);
+		this.borderWidth = new IntSetting(persistence, settingKeyBase + ".border-width", 2, 1, 100);
+		this.borderRoundness = new IntSetting(persistence, settingKeyBase + ".border-roundness", 0, 0, 100);
+		this.rightToLeft = new BooleanSetting(persistence, settingKeyBase + ".right-to-left", true);
+		List.of(spacing, borderWidth, borderRoundness, rightToLeft)
+				.forEach(setting -> setting.addListener(this::notifyListeners));
+		refreshCustoms();
+	}
+
+	private static String getKey(ExtendedCooldownDescriptor buff) {
+		return cdKeyStub + buff.getSettingKeyStub();
+	}
+
+	private static boolean isValidCd(ExtendedCooldownDescriptor cd) {
+		return ActionLibrary.iconForId(cd.getPrimaryAbilityId()) != null && cd.getMaxCharges() <= 1;
+	}
+
+	private synchronized void refreshCustoms() {
+		log.info("Refreshing custom CDs");
+		List<CustomCooldown> customs = customCooldownManager.getCooldowns();
+		partyCdsCustom.clear();
+		for (CustomCooldown custom : customs) {
+			ExtendedCooldownDescriptor cd;
+			try {
+				cd = custom.buildCd();
+			}
+			catch (Throwable t) {
+				log.error("Error loading custom cooldown ({}, {})", custom.nameOverride, String.format("0x%X", custom.primaryAbilityId));
+				continue;
+			}
+			if (isValidCd(cd)) {
+				CustomPartyCdSetting newCdSetting = new CustomPartyCdSetting(persistence, getKey(cd) + ".party", false);
+				setupListener(newCdSetting);
+				partyCdsCustom.put(cd, newCdSetting);
+			}
+		}
+		Map<ExtendedCooldownDescriptor, CustomPartyCdSetting> partyCds = new LinkedHashMap<>();
+		partyCds.putAll(partyCdsCustom);
+		partyCds.putAll(partyCdsBuiltin);
+		this.partyCds = partyCds;
+//		List<ExtendedCooldownDescriptor> all = new ArrayList<>();
+//		all.addAll(partyCds.keySet());
+//		allCds = all;
+		log.info("Number of CDs: {} builtin, {} custom", partyCdsBuiltin.size(), customs.size());
+		notifyListeners();
+	}
+
+	private void setupListener(CustomPartyCdSetting newCdSetting) {
+		newCdSetting.getEnable().addListener(this::notifyListeners);
+	}
+
+	public Map<ExtendedCooldownDescriptor, CustomPartyCdSetting> getSettings() {
+		return Collections.unmodifiableMap(partyCds);
+	}
+
+	public List<ExtendedCooldownDescriptor> getEnabledCds() {
+		return partyCds.entrySet().stream().filter(e -> e.getValue().getEnable().get()).map(Map.Entry::getKey).toList();
+	}
+
+	@HandleEvents
+	public void refreshCustoms(EventContext context, CustomCooldownsUpdated updated) {
+		refreshCustoms();
+	}
+
+	public SettingsCdTrackerColorProvider getColors() {
+		return colors;
+	}
+
+	public IntSetting getSpacing() {
+		return spacing;
+	}
+
+	public IntSetting getBorderRoundness() {
+		return borderRoundness;
+	}
+
+	public BooleanSetting getRightToLeft() {
+		return rightToLeft;
+	}
+
+	public IntSetting getBorderWidth() {
+		return borderWidth;
+	}
+
+	@SuppressWarnings("SuspiciousMethodCalls")
+	private static boolean defaultSetting(ExtendedCooldownDescriptor ecd) {
+		return defaultEnabled.contains(ecd);
+	}
+
+	private static final Set<Cooldown> defaultEnabled = EnumSet.of(
+			Cooldown.HallowedGround,
+			Cooldown.Holmgang,
+			Cooldown.LivingDead,
+			Cooldown.Superbolide,
+			Cooldown.Temperance,
+			Cooldown.Benediction,
+			Cooldown.Swiftcast,
+			Cooldown.ChainStratagem,
+			Cooldown.Expedient,
+			Cooldown.Divination,
+			Cooldown.Panhaima,
+			Cooldown.Brotherhood,
+			Cooldown.Mug,
+			Cooldown.ArcaneCircle,
+			Cooldown.Troubadour,
+			Cooldown.RadiantFinale,
+			Cooldown.TechnicalStep,
+			Cooldown.Devilment,
+			Cooldown.ShieldSamba,
+			Cooldown.SearingLight,
+			Cooldown.Embolden
+	);
+}

--- a/plugins/custom-party-overlay/src/main/java/gg/xp/xivsupport/custompartyoverlay/cdtracker/CustomPartyCdTrackerGui.java
+++ b/plugins/custom-party-overlay/src/main/java/gg/xp/xivsupport/custompartyoverlay/cdtracker/CustomPartyCdTrackerGui.java
@@ -1,0 +1,174 @@
+package gg.xp.xivsupport.custompartyoverlay.cdtracker;
+
+import gg.xp.reevent.events.EventContext;
+import gg.xp.reevent.scan.HandleEvents;
+import gg.xp.xivdata.data.*;
+import gg.xp.xivsupport.cdsupport.CustomCooldownsUpdated;
+import gg.xp.xivsupport.events.triggers.jobs.gui.BaseCdTrackerGui;
+import gg.xp.xivsupport.events.triggers.jobs.gui.SettingsCdTrackerColorProvider;
+import gg.xp.xivsupport.gui.NoCellEditor;
+import gg.xp.xivsupport.gui.WrapLayout;
+import gg.xp.xivsupport.gui.tables.CustomColumn;
+import gg.xp.xivsupport.gui.tables.CustomTableModel;
+import gg.xp.xivsupport.gui.tables.StandardColumns;
+import gg.xp.xivsupport.gui.tables.renderers.ActionAndStatusRenderer;
+import gg.xp.xivsupport.gui.tables.renderers.JobRenderer;
+import gg.xp.xivsupport.models.XivAbility;
+import gg.xp.xivsupport.persistence.gui.BooleanSettingGui;
+import gg.xp.xivsupport.persistence.gui.ColorSettingGui;
+import gg.xp.xivsupport.persistence.gui.IntSettingSpinner;
+
+import javax.swing.*;
+import java.awt.*;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+
+public class CustomPartyCdTrackerGui extends JPanel {
+
+	private final CustomPartyCdTrackerConfig config;
+	private CustomTableModel<CdInfo> model;
+
+	public CustomPartyCdTrackerGui(CustomPartyCdTrackerConfig config) {
+		this.config = config;
+		setLayout(new BorderLayout());
+		JPanel settingsPanel = new JPanel();
+		settingsPanel.setLayout(new WrapLayout());
+
+		settingsPanel.add(new BooleanSettingGui(config.getRightToLeft(), "Right to Left", true).getComponent());
+		settingsPanel.add(new IntSettingSpinner(config.getSpacing(), "Spacing Between Items").getComponent());
+		settingsPanel.add(new IntSettingSpinner(config.getBorderWidth(), "Border Thickness").getComponent());
+		settingsPanel.add(new IntSettingSpinner(config.getBorderRoundness(), "Roundness").getComponent());
+
+		settingsPanel.add(Box.createHorizontalStrut(32_000));
+		SettingsCdTrackerColorProvider colors = config.getColors();
+		settingsPanel.add(new ColorSettingGui(colors.getActiveSetting(), "Active Color", () -> true).getComponent());
+		settingsPanel.add(new ColorSettingGui(colors.getReadySetting(), "Ready Color", () -> true).getComponent());
+		settingsPanel.add(new ColorSettingGui(colors.getOnCdSetting(), "On CD Color", () -> true).getComponent());
+		settingsPanel.add(new ColorSettingGui(colors.getPreappSetting(), "Preapp Color", () -> true).getComponent());
+//		settingsPanel.add(new ColorSettingGui(colors.getFontSetting(), "Font Color", () -> true).getComponent());
+
+		add(settingsPanel, BorderLayout.PAGE_START);
+
+		JTable table = new JTable() {
+			@Override
+			public boolean isCellEditable(int row, int column) {
+				// TODO: make this more official
+				if (getCellEditor(row, column) instanceof NoCellEditor) {
+					return false;
+				}
+				return true;
+			}
+		};
+		model = CustomTableModel.builder(this::getCds)
+				.addColumn(StandardColumns.booleanSettingColumn("Enable", cd -> cd.setting.getEnable(), 50, null))
+				.addColumn(new CustomColumn<>("Job", cdi -> {
+					ExtendedCooldownDescriptor cd = cdi.cd;
+					if (cd.getJob() != null) {
+						return cd.getJob();
+					}
+					else {
+						JobType jobType = cd.getJobType();
+						if (jobType != null) {
+							return jobType.getFriendlyName();
+						}
+						else {
+							return "?";
+						}
+					}
+				},
+						col -> {
+							col.setCellRenderer(new JobRenderer());
+							col.setMinWidth(100);
+							col.setMaxWidth(100);
+							col.setCellEditor(new NoCellEditor());
+						}))
+				.addColumn(new CustomColumn<>("Skill",
+						cdi -> new XivAbility(cdi.cd.getPrimaryAbilityId(), cdi.cd.getLabel()), c -> {
+					c.setCellRenderer(new ActionAndStatusRenderer());
+					c.setCellEditor(new NoCellEditor());
+				}))
+				.addColumn(new CustomColumn<>("Cooldown", cdi -> {
+					ExtendedCooldownDescriptor cd = cdi.cd;
+					int maxCharges = cd.getMaxCharges();
+					if (maxCharges > 1) {
+						return String.format("%s (%d charges)", cd.getCooldown(), maxCharges);
+					}
+					return cd.getCooldown();
+				}, c -> c.setCellEditor(new NoCellEditor())))
+//				.addColumn(new CustomColumn<>("Cooldown (from CSV)", cd -> {
+//					ActionInfo actionInfo = ActionLibrary.forId(cd.getPrimaryAbilityId());
+//					if (actionInfo == null) {
+//						return "null";
+//					}
+//					double cdAi = actionInfo.getCd();
+//					int maxChargesAi = actionInfo.maxCharges();
+//
+//					if (maxChargesAi == cd.getMaxCharges() && cd.getCooldown() == cdAi) {
+//						return "";
+//					}
+//					if (maxChargesAi > 1) {
+//						return String.format("%s (%d charges)", cdAi, maxChargesAi);
+//					}
+//					return cdAi;
+//				}))
+//				.addColumn(new CustomColumn<>("Max Charges", cooldown -> {
+//					int maxCharges = cooldown.getMaxCharges();
+//					return maxCharges > 1 ? maxCharges : null;
+//				}, 100))
+//				.addColumn(new CustomColumn<>("Raw class/job/category", cd -> {
+//					ActionInfo actionInfo = ActionLibrary.forId(cd.getPrimaryAbilityId());
+//					return actionInfo == null ? null : actionInfo.categoryRaw();
+//				}))
+				.build();
+
+		table.setModel(model);
+		table.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
+		model.configureColumns(table);
+
+
+		JScrollPane scroll = new JScrollPane(table);
+		scroll.setVerticalScrollBarPolicy(ScrollPaneConstants.VERTICAL_SCROLLBAR_ALWAYS);
+		add(scroll, BorderLayout.CENTER);
+		config.addListener(model::signalNewData);
+	}
+
+	private record CdInfo(ExtendedCooldownDescriptor cd, CustomPartyCdSetting setting) {
+
+	}
+
+	List<CdInfo> getCds() {
+		Map<ExtendedCooldownDescriptor, CustomPartyCdSetting> cooldowns = config.getSettings();
+		// TODO: idea for how to do separate TTS/visual plus icons
+		// Instead of one checkbox per ability, just have one for TTS, and one for visual, and then
+		// have a label with icon and text.
+		// Alternatively, have a table with a bunch of checkbox columns
+
+		List<CdInfo> sortedCds = new ArrayList<>(cooldowns.entrySet().stream().map(entry -> new CdInfo(entry.getKey(), entry.getValue())).toList());
+		sortedCds.sort(Comparator.comparing(cdi -> {
+			ExtendedCooldownDescriptor cd = cdi.cd;
+			Job job = cd.getJob();
+			// Sort job categories first
+			if (job == null) {
+				JobType jobType = cd.getJobType();
+				if (jobType == null) {
+					// Put custom user-added CDs first
+					return -2;
+				}
+				// Then categories
+				return jobType.ordinal() + 5000;
+			}
+			// Then jobs
+			return job.defaultPartySortOrder() + 10000;
+		}));
+		return sortedCds;
+	}
+
+	@HandleEvents(order = 100)
+	public void cooldownsUpdated(EventContext context, CustomCooldownsUpdated event) {
+		if (model != null) {
+			model.signalNewData();
+		}
+	}
+}

--- a/plugins/custom-party-overlay/src/main/java/gg/xp/xivsupport/custompartyoverlay/cdtracker/CustomPartyCdTrackerGui.java
+++ b/plugins/custom-party-overlay/src/main/java/gg/xp/xivsupport/custompartyoverlay/cdtracker/CustomPartyCdTrackerGui.java
@@ -33,23 +33,23 @@ public class CustomPartyCdTrackerGui extends JPanel {
 	public CustomPartyCdTrackerGui(CustomPartyCdTrackerConfig config) {
 		this.config = config;
 		setLayout(new BorderLayout());
-		JPanel settingsPanel = new JPanel();
-		settingsPanel.setLayout(new WrapLayout());
+		JPanel topSettingsPanel = new JPanel();
+		topSettingsPanel.setLayout(new WrapLayout());
 
-		settingsPanel.add(new BooleanSettingGui(config.getRightToLeft(), "Right to Left", true).getComponent());
-		settingsPanel.add(new IntSettingSpinner(config.getSpacing(), "Spacing Between Items").getComponent());
-		settingsPanel.add(new IntSettingSpinner(config.getBorderWidth(), "Border Thickness").getComponent());
-		settingsPanel.add(new IntSettingSpinner(config.getBorderRoundness(), "Roundness").getComponent());
+		topSettingsPanel.add(new BooleanSettingGui(config.getRightToLeft(), "Right to Left", true).getComponent());
+		topSettingsPanel.add(new IntSettingSpinner(config.getSpacing(), "Spacing Between Items").getComponent());
+		topSettingsPanel.add(new IntSettingSpinner(config.getBorderWidth(), "Border Thickness").getComponent());
+		topSettingsPanel.add(new IntSettingSpinner(config.getBorderRoundness(), "Roundness").getComponent());
 
-		settingsPanel.add(Box.createHorizontalStrut(32_000));
+		topSettingsPanel.add(Box.createHorizontalStrut(32_000));
 		SettingsCdTrackerColorProvider colors = config.getColors();
-		settingsPanel.add(new ColorSettingGui(colors.getActiveSetting(), "Active Color", () -> true).getComponent());
-		settingsPanel.add(new ColorSettingGui(colors.getReadySetting(), "Ready Color", () -> true).getComponent());
-		settingsPanel.add(new ColorSettingGui(colors.getOnCdSetting(), "On CD Color", () -> true).getComponent());
-		settingsPanel.add(new ColorSettingGui(colors.getPreappSetting(), "Preapp Color", () -> true).getComponent());
-//		settingsPanel.add(new ColorSettingGui(colors.getFontSetting(), "Font Color", () -> true).getComponent());
+		topSettingsPanel.add(new ColorSettingGui(colors.getActiveSetting(), "Active Color", () -> true).getComponent());
+		topSettingsPanel.add(new ColorSettingGui(colors.getReadySetting(), "Ready Color", () -> true).getComponent());
+		topSettingsPanel.add(new ColorSettingGui(colors.getOnCdSetting(), "On CD Color", () -> true).getComponent());
+		topSettingsPanel.add(new ColorSettingGui(colors.getPreappSetting(), "Preapp Color", () -> true).getComponent());
+//		topSettingsPanel.add(new ColorSettingGui(colors.getFontSetting(), "Font Color", () -> true).getComponent());
 
-		add(settingsPanel, BorderLayout.PAGE_START);
+		add(topSettingsPanel, BorderLayout.PAGE_START);
 
 		JTable table = new JTable() {
 			@Override
@@ -131,6 +131,10 @@ public class CustomPartyCdTrackerGui extends JPanel {
 		JScrollPane scroll = new JScrollPane(table);
 		scroll.setVerticalScrollBarPolicy(ScrollPaneConstants.VERTICAL_SCROLLBAR_ALWAYS);
 		add(scroll, BorderLayout.CENTER);
+		JPanel bottomBettingsPanel = new JPanel();
+		bottomBettingsPanel.setLayout(new WrapLayout());
+		bottomBettingsPanel.add(new BooleanSettingGui(config.getScOnlyRez(), "Hide Swiftcast on BLM/RDM", true).getComponent());
+		add(bottomBettingsPanel, BorderLayout.SOUTH);
 		config.addListener(model::signalNewData);
 	}
 

--- a/plugins/custom-party-overlay/src/main/java/gg/xp/xivsupport/custompartyoverlay/gui/CustomPartyConfig.java
+++ b/plugins/custom-party-overlay/src/main/java/gg/xp/xivsupport/custompartyoverlay/gui/CustomPartyConfig.java
@@ -247,10 +247,10 @@ public class CustomPartyConfig implements PluginTab {
 					continue;
 				}
 				Component component = rplc.getComponent();
+				dragArea.add(component);
 				Point adjustedLoc = dragArea.logicalToScreen(new Point(item.x, item.y));
 				component.setBounds(adjustedLoc.x, adjustedLoc.y, item.width, item.height);
 				rplc.refresh(dummyCharacter);
-				dragArea.add(component);
 				componentToSpecMapping.put(component, item);
 				specToComponentMapping.put(item, component);
 			}

--- a/xivdata/src/main/java/gg/xp/xivdata/data/Job.java
+++ b/xivdata/src/main/java/gg/xp/xivdata/data/Job.java
@@ -184,4 +184,8 @@ public enum Job implements HasIconURL {
 	public boolean caresAboutInterrupt() {
 		return category == JobType.TANK || category == JobType.PRANGED;
 	}
+
+	public boolean usesSwiftRez() {
+		return category.isHealer() || this == SMN;
+	}
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/14287379/209059142-68067113-56f2-4cf7-b54c-d4ed85a73e05.png)

Same as the normal party CD tracker, but now part of the party list. Default colors are the same but it uses a heavily cut-down list of default CDs. You can turn on/off whatever cooldowns, and customize the colors. Might add numbers later, TBD.

There is also an option to hide swiftcast for RDM/BLM since you'd typically be interested in it for the sake of rezzing.