### PR TITLE
Added addon description field and auto-refreshing of addon info

### DIFF
--- a/xivsupport/src/main/java/gg/xp/xivsupport/gui/addonmgr/AddonMgr.java
+++ b/xivsupport/src/main/java/gg/xp/xivsupport/gui/addonmgr/AddonMgr.java
@@ -1,26 +1,22 @@
 package gg.xp.xivsupport.gui.addonmgr;
 
-import com.formdev.flatlaf.util.ScaledImageIcon;
 import gg.xp.reevent.scan.ScanMe;
 import gg.xp.xivsupport.gui.TitleBorderFullsizePanel;
 import gg.xp.xivsupport.gui.extra.PluginTab;
 import gg.xp.xivsupport.gui.tables.CustomColumn;
 import gg.xp.xivsupport.gui.tables.CustomTableModel;
-import gg.xp.xivsupport.gui.tables.TableWithFilterAndDetails;
 import gg.xp.xivsupport.gui.tables.renderers.AutoHeightScalingIcon;
-import gg.xp.xivsupport.gui.tables.renderers.ComponentListStretchyRenderer;
 import gg.xp.xivsupport.gui.tables.renderers.IconTextRenderer;
+import gg.xp.xivsupport.gui.tables.renderers.MultiLineVerticalCenteredTextRenderer;
 import gg.xp.xivsupport.gui.tables.renderers.ScaledImageComponent;
 import gg.xp.xivsupport.gui.tabs.AddonDef;
 import gg.xp.xivsupport.gui.tabs.UpdaterConfig;
-import gg.xp.xivsupport.gui.util.GuiUtil;
 import gg.xp.xivsupport.persistence.settings.CustomJsonListSetting;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.swing.*;
 import javax.swing.table.DefaultTableCellRenderer;
-import javax.swing.table.TableCellRenderer;
 import java.awt.*;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -112,8 +108,12 @@ public class AddonMgr implements PluginTab {
 						}
 					});
 				}))
-				.addColumn(new CustomColumn<>("Name", item -> item.name))
-				.addColumn(new CustomColumn<>("Subdirectory", item -> item.dirName))
+				.addColumn(new CustomColumn<>("Name", item -> item.name, c -> c.setPreferredWidth(300)))
+				.addColumn(new CustomColumn<>("Description", item -> item.description, c -> {
+					c.setPreferredWidth(1000);
+					c.setCellRenderer(new MultiLineVerticalCenteredTextRenderer("No Description"));
+				}))
+				.addColumn(new CustomColumn<>("Subdirectory", item -> item.dirName, c -> c.setPreferredWidth(200)))
 				.build();
 		addonSetting.addListener(model::signalNewData);
 		JTable table = model.makeTable();

--- a/xivsupport/src/main/java/gg/xp/xivsupport/gui/tables/renderers/MultiLineVerticalCenteredTextRenderer.java
+++ b/xivsupport/src/main/java/gg/xp/xivsupport/gui/tables/renderers/MultiLineVerticalCenteredTextRenderer.java
@@ -1,0 +1,70 @@
+package gg.xp.xivsupport.gui.tables.renderers;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import javax.swing.*;
+import javax.swing.table.DefaultTableCellRenderer;
+import java.awt.*;
+
+public class MultiLineVerticalCenteredTextRenderer extends DefaultTableCellRenderer {
+
+	private final String nullText;
+	private final JPanel panel;
+	private final JTextArea rot;
+	{
+		rot = new JTextArea();
+		panel = new JPanel(null) {
+			@Override
+			public void setBounds(int x, int y, int width, int height) {
+				super.setBounds(x, y, width, height);
+				rot.setBounds(0, 0, width, height);
+				rot.invalidate();
+				int prefHeight = rot.getPreferredSize().height;
+				if (prefHeight > height) {
+					rot.setBounds(0, 0, width, height);
+				}
+				else {
+					int delta = height - prefHeight;
+					rot.setBounds(0, delta / 2, width, prefHeight);
+				}
+			}
+		};
+		rot.setAlignmentY(0.5f);
+		rot.setEditable(false);
+		rot.setWrapStyleWord(true);
+		rot.setLineWrap(true);
+		rot.setFocusable(false);
+		rot.setOpaque(false);
+		panel.add(rot);
+		panel.setOpaque(true);
+		panel.setAlignmentY(0.5f);
+
+	}
+
+	public MultiLineVerticalCenteredTextRenderer() {
+		this("");
+	}
+
+	public MultiLineVerticalCenteredTextRenderer(String nullText) {
+		this.nullText = nullText;
+	}
+
+	protected String objectToText(@Nullable Object value) {
+		return value == null ? nullText : nonNullObjectToText(value);
+	}
+
+	protected String nonNullObjectToText(@NotNull Object value) {
+		return value.toString();
+	}
+
+	@Override
+	public Component getTableCellRendererComponent(JTable table, Object value, boolean isSelected, boolean hasFocus, int row, int column) {
+		String text = objectToText(value);
+		rot.setText(text);
+		Component dflt = super.getTableCellRendererComponent(table, value, isSelected, hasFocus, row, column);
+		panel.setBackground(dflt.getBackground());
+		panel.setForeground(dflt.getForeground());
+		return panel;
+	}
+}

--- a/xivsupport/src/main/java/gg/xp/xivsupport/gui/tabs/AddonDef.java
+++ b/xivsupport/src/main/java/gg/xp/xivsupport/gui/tabs/AddonDef.java
@@ -16,5 +16,16 @@ public class AddonDef {
 	public String urlPattern;
 	@JsonProperty("icon_url")
 	public String iconUrl;
+	@JsonProperty("description")
+	public String description;
+
+	public void readFrom(AddonDef that) {
+		this.name = that.name;
+		this.dirName = that.dirName;
+		this.url = that.url;
+		this.urlPattern = that.urlPattern;
+		this.iconUrl = that.iconUrl;
+		this.description = that.description;
+	}
 
 }

--- a/xivsupport/src/main/java/gg/xp/xivsupport/gui/tabs/UpdaterConfig.java
+++ b/xivsupport/src/main/java/gg/xp/xivsupport/gui/tabs/UpdaterConfig.java
@@ -8,19 +8,26 @@ import gg.xp.xivsupport.persistence.Platform;
 import gg.xp.xivsupport.persistence.SimplifiedPropertiesFilePersistenceProvider;
 import gg.xp.xivsupport.persistence.settings.CustomJsonListSetting;
 import gg.xp.xivsupport.persistence.settings.StringSetting;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import java.nio.file.Paths;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 @ScanMe
 public class UpdaterConfig {
 
+	private static final Logger log = LoggerFactory.getLogger(UpdaterConfig.class);
 	private static final String propsOverrideFileName = "update.properties";
 	private static final Pattern allowedDirName = Pattern.compile("([A-Za-z][A-Za-z0-9-_]+)");
+	private static final ObjectMapper mapper = new ObjectMapper();
 	private final File propsOverride;
 	private final PersistenceProvider updatePropsFilePers;
 	private final File installDir;
@@ -28,6 +35,7 @@ public class UpdaterConfig {
 	private final StringSetting urlTemplateSetting;
 	private final CustomJsonListSetting<AddonDef> addonSetting;
 	private final StringSetting addonUrlsSetting;
+	private final ExecutorService exs = Executors.newCachedThreadPool();
 	private Runnable updateRunnable = () -> {
 
 	};
@@ -42,6 +50,7 @@ public class UpdaterConfig {
 		addonSetting = CustomJsonListSetting.<AddonDef>builder(pers, new TypeReference<>() {
 		}, "update-config.addon-manager.addon-list", "update-config.addon-manager.addon-list-failed").build();
 		addonSetting.addListener(this::syncAddonConfig);
+		exs.submit(this::refreshAddons);
 	}
 
 	public StringSetting getBranchSetting() {
@@ -64,17 +73,21 @@ public class UpdaterConfig {
 		if (!addonInfoUrl.endsWith("INFO")) {
 			addonInfoUrl += "/INFO";
 		}
-		ObjectMapper mapper = new ObjectMapper();
+		AddonDef newAddonDef = getAddonDef(addonInfoUrl);
+		addonSetting.addItem(newAddonDef);
+	}
+
+	private AddonDef getAddonDef(String url) {
 		AddonDef newAddonDef;
 		try {
-			newAddonDef = mapper.readValue(new URL(addonInfoUrl), new TypeReference<>() {
+			newAddonDef = mapper.readValue(new URL(url), new TypeReference<>() {
 			});
 		}
 		catch (IOException e) {
 			throw new RuntimeException(e);
 		}
 		if (newAddonDef.url == null) {
-			newAddonDef.url = addonInfoUrl;
+			newAddonDef.url = url;
 		}
 		if (newAddonDef.name == null) {
 			throw new AddonValidationException("Addon did not have a name");
@@ -88,7 +101,7 @@ public class UpdaterConfig {
 		if (newAddonDef.urlPattern == null) {
 			throw new AddonValidationException("Addon did not define a download URL");
 		}
-		addonSetting.addItem(newAddonDef);
+		return newAddonDef;
 	}
 
 	// TODO: also need a way of refreshing addon info from INFO files, in case the author wants to change the icon,
@@ -99,6 +112,22 @@ public class UpdaterConfig {
 				.map(ad -> ad.dirName + ':' + ad.urlPattern)
 				.collect(Collectors.joining("\n"))
 		);
+	}
+
+	public void refreshAddons() {
+		List<AddonDef> addonsBefore = addonSetting.getItems();
+		addonsBefore.forEach(addon -> {
+			AddonDef addonDef;
+			try {
+				addonDef = getAddonDef(addon.url);
+			}
+			catch (Throwable t) {
+				log.error("Error updating info for addon", t);
+				return;
+			}
+			addon.readFrom(addonDef);
+		});
+		addonSetting.commit();
 	}
 
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/14287379/210622076-18ce63d7-4010-4110-bd78-747ea32c19f0.png)

Example of INFO json:
```json
{
    "name": "Example Module",
    "dir_name": "triggevent-example-module",
    "icon_url": "https://upload.wikimedia.org/wikipedia/commons/thumb/6/66/SMPTE_Color_Bars.svg/672px-SMPTE_Color_Bars.svg.png",
    "webpage_url": "https://github.com/xpdota/triggevent-example-module",
    "url_pattern": "https://raw.githubusercontent.com/xpdota/triggevent-example-module/gh-pages/master/%s",
    "description": "This is a long description. It can span multiple lines.\n\nAlso, here is a line break test."
}
```