### PR TITLE
New 24-line fields

### DIFF
--- a/xivsupport/src/main/java/gg/xp/xivsupport/events/actlines/events/abilityeffect/AbilityEffect.java
+++ b/xivsupport/src/main/java/gg/xp/xivsupport/events/actlines/events/abilityeffect/AbilityEffect.java
@@ -12,6 +12,12 @@ public abstract class AbilityEffect {
 		this.effectType = effectType;
 	}
 
+	protected AbilityEffect(AbilityEffectType effectType) {
+		this.flags = 0;
+		this.value = 0;
+		this.effectType = effectType;
+	}
+
 	public AbilityEffectType getEffectType() {
 		return effectType;
 	}
@@ -29,6 +35,9 @@ public abstract class AbilityEffect {
 	};
 
 	public final String getDescription() {
+		if (flags == 0 && value == 0) {
+			return getBaseDescription();
+		}
 		return String.format("%s (raw: %08x %08x)", getBaseDescription(), flags, value);
 	}
 }

--- a/xivsupport/src/main/java/gg/xp/xivsupport/events/actlines/events/abilityeffect/DamageTakenEffect.java
+++ b/xivsupport/src/main/java/gg/xp/xivsupport/events/actlines/events/abilityeffect/DamageTakenEffect.java
@@ -7,6 +7,10 @@ public class DamageTakenEffect extends BaseDamageEffect {
 		super(flags, value, amount, severity, AbilityEffectType.DAMAGE);
 	}
 
+	public DamageTakenEffect(HitSeverity severity, long amount) {
+		this(0, 0, severity, amount);
+	}
+
 	@Override
 	protected String shortName() {
 		return "D";

--- a/xivsupport/src/main/java/gg/xp/xivsupport/events/actlines/events/abilityeffect/HealEffect.java
+++ b/xivsupport/src/main/java/gg/xp/xivsupport/events/actlines/events/abilityeffect/HealEffect.java
@@ -12,6 +12,10 @@ public class HealEffect extends AbilityEffect implements HasSeverity {
 		onTarget = ((flags >> 8) & 1) == 0;
 	}
 
+	public HealEffect(HitSeverity severity, long amount) {
+		this(0, 0, severity, amount);
+	}
+
 	@Override
 	public HitSeverity getSeverity() {
 		return severity;

--- a/xivsupport/src/main/java/gg/xp/xivsupport/events/actlines/parsers/AbstractACTLineParser.java
+++ b/xivsupport/src/main/java/gg/xp/xivsupport/events/actlines/parsers/AbstractACTLineParser.java
@@ -61,8 +61,10 @@ public abstract class AbstractACTLineParser<F extends Enum<F>> {
 			String line = event.getLogLine();
 			String[] splits = event.getRawFields();
 			Map<F, String> out = new EnumMap<>((Class<F>) enumCls);
+			// Subtract 3 - line number, timestamp, hash
+			int fieldCount = Math.min(groups.size(), splits.length - 3);
 			// TODO: validate number of fields
-			for (int i = 0; i < groups.size(); i++) {
+			for (int i = 0; i < fieldCount; i++) {
 				// i + 2 is because the first two are the line number and timestamp.
 				out.put(groups.get(i), splits[i + 2]);
 			}

--- a/xivsupport/src/main/java/gg/xp/xivsupport/events/actlines/parsers/FieldMapper.java
+++ b/xivsupport/src/main/java/gg/xp/xivsupport/events/actlines/parsers/FieldMapper.java
@@ -74,6 +74,10 @@ public class FieldMapper<K extends Enum<K>> {
 		return Double.parseDouble(rawStr);
 	}
 
+	public int fieldCount() {
+		return rawLineSplit.length;
+	}
+
 	public List<String> getRawLineSplit() {
 		return Arrays.asList(rawLineSplit);
 	}
@@ -112,6 +116,10 @@ public class FieldMapper<K extends Enum<K>> {
 
 	public XivCombatant getEntity(K idKey, K nameKey, K currentHpKey, K maxHpKey, K currentMpKey, K maxMpKey, K posXKey, K posYKey, K posZKey, K headingKey) {
 		return getEntity(idKey, nameKey, currentHpKey, maxHpKey, currentMpKey, maxMpKey, posXKey, posYKey, posZKey, headingKey, null);
+	}
+
+	public boolean hasField(K field) {
+		return raw.containsKey(field);
 	}
 
 	public XivCombatant getEntity(K idKey, K nameKey, K currentHpKey, K maxHpKey, K currentMpKey, K maxMpKey, K posXKey, K posYKey, K posZKey, K headingKey, K shieldPctKey) {

--- a/xivsupport/src/main/java/gg/xp/xivsupport/events/actlines/parsers/Line24Parser.java
+++ b/xivsupport/src/main/java/gg/xp/xivsupport/events/actlines/parsers/Line24Parser.java
@@ -1,8 +1,10 @@
 package gg.xp.xivsupport.events.actlines.parsers;
 
 import gg.xp.reevent.events.Event;
+import gg.xp.xivsupport.events.actlines.events.GroundTickEvent;
 import gg.xp.xivsupport.events.actlines.events.TickEvent;
 import gg.xp.xivsupport.events.actlines.events.TickType;
+import gg.xp.xivsupport.events.actlines.events.abilityeffect.DamageType;
 import gg.xp.xivsupport.models.XivCombatant;
 import org.picocontainer.PicoContainer;
 import org.slf4j.Logger;
@@ -24,7 +26,8 @@ public class Line24Parser extends AbstractACTLineParser<Line24Parser.Fields> {
 		dotOrHot,
 		effectId,
 		damage,
-		targetCurHp, targetMaxHp, targetCurMp, targetMaxMp, targetUnknown1, targetUnknown2, targetX, targetY, targetZ, targetHeading
+		targetCurHp, targetMaxHp, targetCurMp, targetMaxMp, targetUnknown1, targetUnknown2, targetX, targetY, targetZ, targetHeading,
+		sourceId, sourceName, damageType, sourceCurHp, sourceMaxHp, sourceCurMp, sourceMaxMp, sourceUnknown1, sourceUnknown2, sourceX, sourceY, sourceZ, sourceHeading
 	}
 
 	@Override
@@ -32,6 +35,7 @@ public class Line24Parser extends AbstractACTLineParser<Line24Parser.Fields> {
 		XivCombatant target = fields.getEntity(Fields.targetId, Fields.targetName, Fields.targetCurHp, Fields.targetMaxHp, Fields.targetCurMp, Fields.targetMaxMp, Fields.targetX, Fields.targetY, Fields.targetZ, Fields.targetHeading);
 		// Not sure what to do yet, atm only care about the combatant update, but this *could* be useful for server tickers
 		String which = fields.getString(Fields.dotOrHot);
+		long effectId = fields.getHex(Fields.effectId);
 		final TickType type;
 		switch (which) {
 			case "DoT" -> type = TickType.DOT;
@@ -41,7 +45,17 @@ public class Line24Parser extends AbstractACTLineParser<Line24Parser.Fields> {
 				return null;
 			}
 		}
-		return new TickEvent(target, type, fields.getHex(Fields.damage), fields.getHex(Fields.effectId));
+		long damage = fields.getHex(Fields.damage);
+		if (fields.hasField(Fields.damageType) && fields.hasField(Fields.sourceId) && effectId != 0) {
+			// 6.3+ path specifically for ground effects
+			DamageType damageType = DamageType.forByte(fields.getInt(Fields.damageType));
+			XivCombatant source = fields.getEntity(Fields.sourceId, Fields.sourceName, Fields.sourceCurHp, Fields.sourceMaxHp, Fields.sourceCurMp, Fields.sourceMaxMp, Fields.sourceX, Fields.sourceY, Fields.sourceZ, Fields.sourceHeading);
+			return new GroundTickEvent(target, type, damage, damageType, effectId, source);
+		}
+		else {
+			// Combined tick + legacy ground ticks
+			return new TickEvent(target, type, damage, effectId);
+		}
 		// TODO: is HP coming from network for this? Or memory? If the former, could be trusted.
 	}
 }


### PR DESCRIPTION
It can now determine source and damage type for ground effects. 

While this data *is* also present for combined DoT/HoT ticks, it seems to reflect only the most recent DoT. This could be misleading, so I've elected to not expose this information for combined ticks.