### PR TITLE
Postnamazu support

### DIFF
--- a/launcher/pom.xml
+++ b/launcher/pom.xml
@@ -378,6 +378,10 @@
             <groupId>gg.xp</groupId>
             <artifactId>skill-hit-overlay</artifactId>
         </dependency>
+        <dependency>
+            <groupId>gg.xp</groupId>
+            <artifactId>postnamazu-core</artifactId>
+        </dependency>
 <!--        <dependency>-->
 <!--            <groupId>gg.xp</groupId>-->
 <!--            <artifactId>telesto-subscriber</artifactId>-->

--- a/launcher/pom.xml
+++ b/launcher/pom.xml
@@ -382,6 +382,10 @@
             <groupId>gg.xp</groupId>
             <artifactId>postnamazu-core</artifactId>
         </dependency>
+        <dependency>
+            <groupId>gg.xp</groupId>
+            <artifactId>postnamazu-gui</artifactId>
+        </dependency>
 <!--        <dependency>-->
 <!--            <groupId>gg.xp</groupId>-->
 <!--            <artifactId>telesto-subscriber</artifactId>-->

--- a/pom.xml
+++ b/pom.xml
@@ -389,6 +389,11 @@
                 <artifactId>postnamazu-core</artifactId>
                 <version>${project.version}</version>
             </dependency>
+            <dependency>
+                <groupId>gg.xp</groupId>
+                <artifactId>postnamazu-gui</artifactId>
+                <version>${project.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -425,5 +430,6 @@
         <module>trigger-support</module>
         <module>persistence</module>
         <module>postnamazu-support</module>
+        <module>postnamazu-support/postnamazu-gui</module>
     </modules>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -419,5 +419,6 @@
         <module>groovy-sandboxing</module>
         <module>trigger-support</module>
         <module>persistence</module>
+        <module>postnamazu-support</module>
     </modules>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -384,6 +384,11 @@
                 <artifactId>telesto-subscriber</artifactId>
                 <version>${project.version}</version>
             </dependency>
+            <dependency>
+                <groupId>gg.xp</groupId>
+                <artifactId>postnamazu-core</artifactId>
+                <version>${project.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/postnamazu-support/pom.xml
+++ b/postnamazu-support/pom.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>gg.xp</groupId>
+        <artifactId>triggevent</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+    <packaging>pom</packaging>
+    <modules>
+        <module>postnamazu-core</module>
+    </modules>
+
+    <artifactId>postnamazu-support</artifactId>
+
+</project>

--- a/postnamazu-support/postnamazu-core/pom.xml
+++ b/postnamazu-support/postnamazu-core/pom.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>gg.xp</groupId>
+        <artifactId>postnamazu-support</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>postnamazu-core</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>gg.xp</groupId>
+            <artifactId>persistence</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>gg.xp</groupId>
+            <artifactId>xivsupport</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/postnamazu-support/postnamazu-core/src/main/java/gg/xp/Main.java
+++ b/postnamazu-support/postnamazu-core/src/main/java/gg/xp/Main.java
@@ -1,0 +1,7 @@
+package gg.xp;
+
+public class Main {
+	public static void main(String[] args) {
+		System.out.println("Hello world!");
+	}
+}

--- a/postnamazu-support/postnamazu-core/src/main/java/gg/xp/Main.java
+++ b/postnamazu-support/postnamazu-core/src/main/java/gg/xp/Main.java
@@ -1,7 +1,0 @@
-package gg.xp;
-
-public class Main {
-	public static void main(String[] args) {
-		System.out.println("Hello world!");
-	}
-}

--- a/postnamazu-support/postnamazu-core/src/main/java/gg/xp/postnamazu/PnAutoMarkHandler.java
+++ b/postnamazu-support/postnamazu-core/src/main/java/gg/xp/postnamazu/PnAutoMarkHandler.java
@@ -60,8 +60,12 @@ public class PnAutoMarkHandler implements FilteredEventHandler {
 		if (mark == CLEAR) {
 			MarkerSign existingMarker = pmr.signOnCombatant(target);
 			if (existingMarker != null) {
+				// https://github.com/Natsukage/PostNamazu/issues/32#issuecomment-1478739976
+				// Clearing a mark is done by marking 0xE000000 with the marker you wish to clear.
+				// When you do `/mk clear`, the game does more or less the same logic.
 				context.accept(new PnOutgoingMessage("mark", Map.of(
 								// Yes, this is E00_0000 rather than E000_0000
+								// I don't know why, the resulting packet still shows E000_0000
 								"ActorID", 0xE00_0000,
 								"MarkType", existingMarker.getCommand(AutoMarkLanguage.EN)
 						))

--- a/postnamazu-support/postnamazu-core/src/main/java/gg/xp/postnamazu/PnAutoMarkHandler.java
+++ b/postnamazu-support/postnamazu-core/src/main/java/gg/xp/postnamazu/PnAutoMarkHandler.java
@@ -1,0 +1,124 @@
+package gg.xp.postnamazu;
+
+import gg.xp.reevent.events.EventContext;
+import gg.xp.reevent.scan.FilteredEventHandler;
+import gg.xp.reevent.scan.HandleEvents;
+import gg.xp.services.ServiceDescriptor;
+import gg.xp.services.ServiceHandle;
+import gg.xp.xivsupport.events.triggers.marks.AutoMarkLanguage;
+import gg.xp.xivsupport.events.triggers.marks.AutoMarkRequest;
+import gg.xp.xivsupport.events.triggers.marks.ClearAutoMarkRequest;
+import gg.xp.xivsupport.events.triggers.marks.adv.AutoMarkServiceSelector;
+import gg.xp.xivsupport.events.triggers.marks.adv.MarkerSign;
+import gg.xp.xivsupport.events.triggers.marks.adv.SpecificAutoMarkRequest;
+
+import java.util.Map;
+
+import static gg.xp.xivsupport.events.triggers.marks.adv.MarkerSign.*;
+
+public class PnAutoMarkHandler implements FilteredEventHandler {
+
+	private final ServiceHandle pn;
+	private int atkCounter;
+	private int ignCounter;
+	private int bindCounter;
+
+	public PnAutoMarkHandler(AutoMarkServiceSelector serv) {
+		pn = serv.register(ServiceDescriptor.of("postnamazu", "PostNamazu (Requires ACT Plugin)", 11));
+	}
+
+	@HandleEvents(order = -10_000)
+	public void handleSpecificAm(EventContext context, SpecificAutoMarkRequest amr) {
+		if (amr.isHandled()) {
+			return;
+		}
+		MarkerSign mark = amr.getMarker();
+		if (mark == CLEAR) {
+			context.accept(new PnOutgoingMessage("mark", Map.of(
+							"ActorID", amr.getTarget().getId(),
+							"MarkType", 0
+					))
+			);
+		}
+		else {
+			MarkerSign markerToPlace = switch (mark) {
+				case ATTACK_NEXT -> nextEmptyAtk();
+				case BIND_NEXT -> nextEmptyBind();
+				case IGNORE_NEXT -> nextEmptyIgn();
+				default -> mark;
+			};
+			context.accept(new PnOutgoingMessage("mark", Map.of(
+							"ActorID", amr.getTarget().getId(),
+							"MarkType", markerToPlace.getCommand(AutoMarkLanguage.EN)
+					))
+			);
+		}
+		amr.setHandled();
+	}
+
+	@HandleEvents(order = -10_000)
+	public void handleAm(EventContext context, AutoMarkRequest amr) {
+		if (amr.isHandled()) {
+			return;
+		}
+		context.accept(new PnOutgoingMessage("mark", Map.of(
+						"ActorID", amr.getTarget().getId(),
+						"MarkType", nextEmptyAtk().getCommand(AutoMarkLanguage.EN)
+				))
+		);
+		amr.setHandled();
+	}
+
+	private MarkerSign nextEmptyAtk() {
+		return switch (atkCounter = (atkCounter + 1) % 5) {
+			case 0 -> ATTACK5;
+			case 1 -> ATTACK1;
+			case 2 -> ATTACK2;
+			case 3 -> ATTACK3;
+			case 4 -> ATTACK4;
+			default -> throw new IllegalArgumentException("Bad value: " + atkCounter);
+		};
+	}
+
+	private MarkerSign nextEmptyBind() {
+		return switch (bindCounter = (bindCounter + 1) % 3) {
+			case 0 -> BIND3;
+			case 1 -> BIND1;
+			case 2 -> BIND2;
+			default -> throw new IllegalArgumentException("Bad value: " + bindCounter);
+		};
+	}
+
+	private MarkerSign nextEmptyIgn() {
+		return switch (ignCounter = (ignCounter + 1) % 2) {
+			case 0 -> IGNORE2;
+			case 1 -> IGNORE1;
+			default -> throw new IllegalArgumentException("Bad value: " + ignCounter);
+		};
+	}
+
+	@HandleEvents(order = -10_000)
+	public void handleClear(EventContext context, ClearAutoMarkRequest clear) {
+		if (clear.isHandled()) {
+			return;
+		}
+		context.accept(new PnGameCommand("/mk clear <1>"));
+		context.accept(new PnGameCommand("/mk clear <2>"));
+		context.accept(new PnGameCommand("/mk clear <3>"));
+		context.accept(new PnGameCommand("/mk clear <4>"));
+		context.accept(new PnGameCommand("/mk clear <5>"));
+		context.accept(new PnGameCommand("/mk clear <6>"));
+		context.accept(new PnGameCommand("/mk clear <7>"));
+		context.accept(new PnGameCommand("/mk clear <8>"));
+		atkCounter = 0;
+		bindCounter = 0;
+		ignCounter = 0;
+		clear.setHandled();
+	}
+
+
+	@Override
+	public boolean enabled(EventContext context) {
+		return pn.enabled();
+	}
+}

--- a/postnamazu-support/postnamazu-core/src/main/java/gg/xp/postnamazu/PnGameCommand.java
+++ b/postnamazu-support/postnamazu-core/src/main/java/gg/xp/postnamazu/PnGameCommand.java
@@ -1,0 +1,22 @@
+package gg.xp.postnamazu;
+
+import gg.xp.reevent.events.BaseEvent;
+import gg.xp.xivsupport.events.actlines.events.HasPrimaryValue;
+
+public class PnGameCommand extends BaseEvent implements HasPrimaryValue {
+
+	private final String command;
+
+	public PnGameCommand(String command) {
+		this.command = command;
+	}
+
+	public String getCommand() {
+		return command;
+	}
+
+	@Override
+	public String getPrimaryValue() {
+		return command;
+	}
+}

--- a/postnamazu-support/postnamazu-core/src/main/java/gg/xp/postnamazu/PnMain.java
+++ b/postnamazu-support/postnamazu-core/src/main/java/gg/xp/postnamazu/PnMain.java
@@ -1,0 +1,127 @@
+package gg.xp.postnamazu;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import gg.xp.reevent.events.EventContext;
+import gg.xp.reevent.events.EventMaster;
+import gg.xp.reevent.scan.HandleEvents;
+import gg.xp.xivsupport.persistence.PersistenceProvider;
+import gg.xp.xivsupport.persistence.settings.HttpURISetting;
+import gg.xp.xivsupport.persistence.settings.IntSetting;
+import gg.xp.xivsupport.sys.PrimaryLogSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+public class PnMain {
+	private static final Logger log = LoggerFactory.getLogger(PnMain.class);
+	// Being used as a queue
+	private static final ExecutorService cmdQueue = Executors.newSingleThreadExecutor();
+	private static final ExecutorService amQueue = Executors.newSingleThreadExecutor();
+	// Handles the actual execution
+	private static final ExecutorService exs = Executors.newCachedThreadPool();
+	private final HttpClient http = HttpClient.newBuilder().build();
+	private final ObjectMapper mapper = new ObjectMapper();
+	private final HttpURISetting uriSetting;
+	private final EventMaster master;
+
+	private volatile PnStatus status = PnStatus.UNKNOWN;
+	private final PrimaryLogSource pls;
+	private final IntSetting cmdDelayBase;
+	private final IntSetting cmdDelayPlus;
+	private final IntSetting amDelayBase;
+	private final IntSetting amDelayPlus;
+
+	public PnMain(EventMaster master, PersistenceProvider pers, PrimaryLogSource pls) {
+		this.master = master;
+		this.pls = pls;
+		try {
+			uriSetting = new HttpURISetting(pers, "pn-support.uri", new URI("http://localhost:2019/"));
+			cmdDelayBase = new IntSetting(pers, "pn-support.base-cmd-delay", 150, 0, 5000);
+			cmdDelayPlus = new IntSetting(pers, "pn-support.plus-cmd-delay", 150, 0, 5000);
+			amDelayBase = new IntSetting(pers, "pn-support.base-am-delay", 150, 0, 5000);
+			amDelayPlus = new IntSetting(pers, "pn-support.plus-am-delay", 150, 0, 5000);
+		}
+		catch (URISyntaxException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@HandleEvents
+	public void handleOutgoing(EventContext context, PnOutgoingMessage message) {
+		Runnable task = () -> {
+			try {
+				HttpResponse<String> response = sendMessageDirectly(message.getCommand(), message.getPayload());
+				updateStatus(PnStatus.GOOD);
+			}
+			catch (Throwable e) {
+				updateStatus(PnStatus.BAD);
+			}
+		};
+		if (message.getCommand().equals("command")) {
+			cmdQueue.submit(() -> {
+				try {
+					// Insert delay to avoid spamming
+					int delay = (int) (cmdDelayBase.get() + (Math.random() * cmdDelayPlus.get()));
+					Thread.sleep(delay);
+				}
+				catch (InterruptedException e) {
+					log.error("Interrupted", e);
+				}
+				finally {
+					exs.submit(task);
+				}
+			});
+		}
+		else if (message.getCommand().equals("mark")) {
+			amQueue.submit(() -> {
+				try {
+					// Insert delay to avoid spamming
+					int delay = (int) (amDelayBase.get() + (Math.random() * amDelayPlus.get()));
+					Thread.sleep(delay);
+				}
+				catch (InterruptedException e) {
+					log.error("Interrupted", e);
+				}
+				finally {
+					exs.submit(task);
+				}
+			});
+		}
+		else {
+			exs.submit(task);
+		}
+	}
+
+	private void updateStatus(PnStatus status) {
+		this.status = status;
+	}
+
+	public HttpResponse<String> sendMessageDirectly(String command, Object payload) {
+		String body;
+		try {
+			body = mapper.writeValueAsString(payload);
+			HttpResponse<String> response = http.send(
+					HttpRequest
+							.newBuilder(uriSetting.get().resolve(command))
+							.POST(
+									HttpRequest.BodyPublishers
+											.ofString(body)).build(),
+					HttpResponse.BodyHandlers.ofString());
+			if (response.statusCode() != 200) {
+				log.error("PostNamazu: Response failure: {}: {}", response.statusCode(), response.body());
+			}
+			return response;
+		}
+		catch (IOException | InterruptedException e) {
+			throw new RuntimeException(e);
+		}
+	}
+}

--- a/postnamazu-support/postnamazu-core/src/main/java/gg/xp/postnamazu/PnMain.java
+++ b/postnamazu-support/postnamazu-core/src/main/java/gg/xp/postnamazu/PnMain.java
@@ -136,4 +136,28 @@ public class PnMain implements FilteredEventHandler {
 	public boolean enabled(EventContext context) {
 		return pls.getLogSource() == KnownLogSource.WEBSOCKET_LIVE;
 	}
+
+	public IntSetting getAmDelayBase() {
+		return amDelayBase;
+	}
+
+	public IntSetting getAmDelayPlus() {
+		return amDelayPlus;
+	}
+
+	public IntSetting getCmdDelayBase() {
+		return cmdDelayBase;
+	}
+
+	public IntSetting getCmdDelayPlus() {
+		return cmdDelayPlus;
+	}
+
+	public PnStatus getStatus() {
+		return status;
+	}
+
+	public HttpURISetting getUriSetting() {
+		return uriSetting;
+	}
 }

--- a/postnamazu-support/postnamazu-core/src/main/java/gg/xp/postnamazu/PnOutgoingMessage.java
+++ b/postnamazu-support/postnamazu-core/src/main/java/gg/xp/postnamazu/PnOutgoingMessage.java
@@ -3,8 +3,12 @@ package gg.xp.postnamazu;
 import gg.xp.reevent.events.BaseEvent;
 import gg.xp.xivsupport.events.actlines.events.HasPrimaryValue;
 
+import java.io.Serial;
+
 public class PnOutgoingMessage extends BaseEvent implements HasPrimaryValue {
 
+	@Serial
+	private static final long serialVersionUID = 5779519876994337089L;
 	private final String command;
 	private final Object payload;
 
@@ -25,4 +29,5 @@ public class PnOutgoingMessage extends BaseEvent implements HasPrimaryValue {
 	public String getPrimaryValue() {
 		return String.format("%s: %s", command, payload);
 	}
+
 }

--- a/postnamazu-support/postnamazu-core/src/main/java/gg/xp/postnamazu/PnOutgoingMessage.java
+++ b/postnamazu-support/postnamazu-core/src/main/java/gg/xp/postnamazu/PnOutgoingMessage.java
@@ -1,0 +1,28 @@
+package gg.xp.postnamazu;
+
+import gg.xp.reevent.events.BaseEvent;
+import gg.xp.xivsupport.events.actlines.events.HasPrimaryValue;
+
+public class PnOutgoingMessage extends BaseEvent implements HasPrimaryValue {
+
+	private final String command;
+	private final Object payload;
+
+	public PnOutgoingMessage(String command, Object payload) {
+		this.command = command;
+		this.payload = payload;
+	}
+
+	public String getCommand() {
+		return command;
+	}
+
+	public Object getPayload() {
+		return payload;
+	}
+
+	@Override
+	public String getPrimaryValue() {
+		return String.format("%s: %s", command, payload);
+	}
+}

--- a/postnamazu-support/postnamazu-core/src/main/java/gg/xp/postnamazu/PnStatus.java
+++ b/postnamazu-support/postnamazu-core/src/main/java/gg/xp/postnamazu/PnStatus.java
@@ -1,0 +1,7 @@
+package gg.xp.postnamazu;
+
+public enum PnStatus {
+	GOOD,
+	BAD,
+	UNKNOWN
+}

--- a/postnamazu-support/postnamazu-core/src/main/java/gg/xp/postnamazu/PnStatusUpdatedEvent.java
+++ b/postnamazu-support/postnamazu-core/src/main/java/gg/xp/postnamazu/PnStatusUpdatedEvent.java
@@ -1,0 +1,36 @@
+package gg.xp.postnamazu;
+
+import gg.xp.reevent.events.BaseEvent;
+import gg.xp.xivsupport.events.actlines.events.HasPrimaryValue;
+
+import java.io.Serial;
+
+public class PnStatusUpdatedEvent extends BaseEvent implements HasPrimaryValue {
+	@Serial
+	private static final long serialVersionUID = 673924008017979056L;
+	private final PnStatus oldStatus;
+	private final PnStatus newStatus;
+
+	public PnStatusUpdatedEvent(PnStatus oldStatus, PnStatus newStatus) {
+		this.oldStatus = oldStatus;
+		this.newStatus = newStatus;
+	}
+
+	public PnStatus getOldStatus() {
+		return oldStatus;
+	}
+
+	public PnStatus getNewStatus() {
+		return newStatus;
+	}
+
+	@Override
+	public String getPrimaryValue() {
+		return String.format("%s -> %s", oldStatus, newStatus);
+	}
+
+	@Override
+	public boolean shouldSave() {
+		return true;
+	}
+}

--- a/postnamazu-support/postnamazu-gui/pom.xml
+++ b/postnamazu-support/postnamazu-gui/pom.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>gg.xp</groupId>
+        <artifactId>triggevent</artifactId>
+        <version>1.0-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>postnamazu-gui</artifactId>
+    <dependencies>
+        <dependency>
+            <groupId>gg.xp</groupId>
+            <artifactId>postnamazu-core</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/postnamazu-support/postnamazu-gui/src/main/java/gg/xp/postnamazu/gui/PnGui.java
+++ b/postnamazu-support/postnamazu-gui/src/main/java/gg/xp/postnamazu/gui/PnGui.java
@@ -1,0 +1,118 @@
+package gg.xp.postnamazu.gui;
+
+import gg.xp.postnamazu.PnGameCommand;
+import gg.xp.postnamazu.PnMain;
+import gg.xp.postnamazu.PnStatusUpdatedEvent;
+import gg.xp.reevent.events.EventContext;
+import gg.xp.reevent.events.EventMaster;
+import gg.xp.reevent.scan.HandleEvents;
+import gg.xp.xivsupport.events.misc.EchoEvent;
+import gg.xp.xivsupport.gui.TitleBorderFullsizePanel;
+import gg.xp.xivsupport.gui.TitleBorderPanel;
+import gg.xp.xivsupport.gui.WrapLayout;
+import gg.xp.xivsupport.gui.extra.PluginTab;
+import gg.xp.xivsupport.gui.util.GuiUtil;
+import gg.xp.xivsupport.persistence.gui.HttpURISettingGui;
+import gg.xp.xivsupport.persistence.gui.IntSettingSpinner;
+
+import javax.swing.*;
+import java.awt.*;
+
+public class PnGui implements PluginTab {
+
+	private static final String testEchoMsg = "PN Test Message";
+
+	private final EventMaster master;
+	private final PnMain backend;
+	private final JLabel statusLabel;
+	private final JTextArea textArea;
+	private PnGameCommand lastEvent;
+
+	public PnGui(EventMaster master, PnMain backend) {
+		this.master = master;
+		this.backend = backend;
+		this.statusLabel = new JLabel();
+		textArea = new JTextArea("Press the 'Test' button");
+		updateLabel();
+	}
+
+	private void updateLabel() {
+		statusLabel.setText("Status: " + backend.getStatus());
+	}
+
+	@Override
+	public String getTabName() {
+		return "PostNamazu";
+	}
+
+	@Override
+	public Component getTabContents() {
+		TitleBorderFullsizePanel outer = new TitleBorderFullsizePanel("PostNamazu");
+		JPanel uriControl = new HttpURISettingGui(backend.getUriSetting(), "Base URI").getComponent();
+		JPanel testPanel;
+		JScrollPane scroll;
+		{
+			testPanel = new JPanel(new FlowLayout(FlowLayout.LEFT));
+			JButton test = new JButton("Test");
+			test.addActionListener(l -> {
+				sendTestEvent();
+			});
+			testPanel.add(test);
+			scroll = new JScrollPane(textArea);
+			scroll.setMinimumSize(new Dimension(390, 390));
+			scroll.setPreferredSize(new Dimension(390, 390));
+//			testPanel.add(scroll);
+			Dimension pref = testPanel.getPreferredSize();
+			Dimension newPref = new Dimension(pref.width + 40, pref.height);
+			testPanel.setPreferredSize(newPref);
+			testPanel.setMinimumSize(newPref);
+			testPanel.setMaximumSize(newPref);
+		}
+//		JCheckBox partyListCb = new BooleanSettingGui(backend.getEnablePartyList(), "Enable Party List").getComponent();
+//		JCheckBox rightClicksCb = new BooleanSettingGui(trco.getEnableExtraOptions(), "Install Right Click Debug Options").getComponent();
+		TitleBorderPanel amDelayPanel = new TitleBorderPanel("Marker Delays");
+		{
+			amDelayPanel.setLayout(new WrapLayout());
+			amDelayPanel.add(new JLabel("Between marks, delay "));
+			amDelayPanel.add(new IntSettingSpinner(backend.getAmDelayBase(), "ms").getSpinnerOnly());
+			amDelayPanel.add(new JLabel("ms,"));
+			amDelayPanel.add(new JLabel("plus a random delay up to "));
+			amDelayPanel.add(new IntSettingSpinner(backend.getAmDelayPlus(), "").getSpinnerOnly());
+			amDelayPanel.add(new JLabel("ms."));
+		}
+		TitleBorderPanel cmdDelayPanel = new TitleBorderPanel("Command Delays");
+		{
+			cmdDelayPanel.setLayout(new WrapLayout());
+			cmdDelayPanel.add(new JLabel("Between commands, delay "));
+			cmdDelayPanel.add(new IntSettingSpinner(backend.getAmDelayBase(), "ms").getSpinnerOnly());
+			cmdDelayPanel.add(new JLabel("ms,"));
+			cmdDelayPanel.add(new JLabel("plus a random delay up to "));
+			cmdDelayPanel.add(new IntSettingSpinner(backend.getAmDelayPlus(), "").getSpinnerOnly());
+			cmdDelayPanel.add(new JLabel("ms."));
+		}
+
+
+		GuiUtil.simpleTopDownLayout(outer, 400, uriControl, Box.createRigidArea(new Dimension(390, 5)), scroll, testPanel, amDelayPanel, cmdDelayPanel);
+		outer.invalidate();
+
+		return outer;
+	}
+
+	private void sendTestEvent() {
+		textArea.setText("Waiting for response...");
+		lastEvent = new PnGameCommand("/e " + testEchoMsg);
+		master.pushEvent(lastEvent);
+	}
+
+	@HandleEvents
+	public void handleConnectionStatusChange(EventContext context, PnStatusUpdatedEvent event) {
+		updateLabel();
+	}
+
+	@HandleEvents
+	public void handleEchoEvent(EventContext context, EchoEvent event) {
+		if (event.getLine().equals(testEchoMsg)) {
+			textArea.setText("Success!");
+		}
+	}
+}

--- a/telesto-support/telesto-core/src/main/java/gg/xp/telestosupport/TelestoAutoMarkHandler.java
+++ b/telesto-support/telesto-core/src/main/java/gg/xp/telestosupport/TelestoAutoMarkHandler.java
@@ -3,11 +3,16 @@ package gg.xp.telestosupport;
 import gg.xp.reevent.events.EventContext;
 import gg.xp.reevent.scan.FilteredEventHandler;
 import gg.xp.reevent.scan.HandleEvents;
+import gg.xp.services.ServiceDescriptor;
+import gg.xp.services.ServiceHandle;
 import gg.xp.xivsupport.events.triggers.marks.AutoMarkHandler;
 import gg.xp.xivsupport.events.triggers.marks.AutoMarkSlotRequest;
 import gg.xp.xivsupport.events.triggers.marks.ClearAutoMarkRequest;
+import gg.xp.xivsupport.events.triggers.marks.adv.AutoMarkServiceSelector;
 import gg.xp.xivsupport.events.triggers.marks.adv.MarkerSign;
 import gg.xp.xivsupport.events.triggers.marks.adv.SpecificAutoMarkSlotRequest;
+import gg.xp.xivsupport.persistence.PersistenceProvider;
+import gg.xp.xivsupport.persistence.settings.BooleanSetting;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -15,23 +20,34 @@ public class TelestoAutoMarkHandler implements FilteredEventHandler {
 
 	private static final Logger log = LoggerFactory.getLogger(TelestoAutoMarkHandler.class);
 	private final AutoMarkHandler am;
+	private final ServiceHandle handle;
 
-	public TelestoAutoMarkHandler(AutoMarkHandler am) {
+	public TelestoAutoMarkHandler(PersistenceProvider pers, AutoMarkHandler am, AutoMarkServiceSelector serv) {
 		this.am = am;
+		BooleanSetting legacySetting = new BooleanSetting(pers, "auto-marks.use-telesto", false);
+		handle = serv.register(ServiceDescriptor.of("telesto-am", "Telesto (Requires Dalamud Plugin)", legacySetting.get() ? 20 : 12));
 	}
 
 	@HandleEvents
 	public void doAutoMark(EventContext context, AutoMarkSlotRequest event) {
+		if (event.isHandled()) {
+			return;
+		}
 		context.accept(new TelestoGameCommand(String.format("/mk attack <%s>", event.getSlotToMark())));
+		event.setHandled();
 	}
 
 	@HandleEvents
 	public void doSpecificAutoMark(EventContext context, SpecificAutoMarkSlotRequest event) {
+		if (event.isHandled()) {
+			return;
+		}
 		MarkerSign marker = event.getMarker();
 		context.accept(new TelestoGameCommand(String.format(
 				"/mk %s <%s>",
 				marker.getCommand(am.getEffectiveLanguage()),
 				event.getSlotToMark())));
+		event.setHandled();
 	}
 
 	private void clearAutoMark(EventContext context) {
@@ -48,13 +64,17 @@ public class TelestoAutoMarkHandler implements FilteredEventHandler {
 	@HandleEvents
 //	@LiveOnly
 	public void clearMarks(EventContext context, ClearAutoMarkRequest event) {
+		if (event.isHandled()) {
+			return;
+		}
 		log.info("Clearing marks");
 		clearAutoMark(context);
+		event.setHandled();
 	}
 
 
 	@Override
 	public boolean enabled(EventContext context) {
-		return am.getUseTelesto().get();
+		return handle.enabled();
 	}
 }

--- a/telesto-support/telesto-gui/src/main/java/gg/xp/telestosupport/gui/TelestoGui.java
+++ b/telesto-support/telesto-gui/src/main/java/gg/xp/telestosupport/gui/TelestoGui.java
@@ -17,7 +17,6 @@ import gg.xp.xivsupport.gui.TitleBorderFullsizePanel;
 import gg.xp.xivsupport.gui.TitleBorderPanel;
 import gg.xp.xivsupport.gui.WrapLayout;
 import gg.xp.xivsupport.gui.extra.PluginTab;
-import gg.xp.xivsupport.gui.tabs.TabAware;
 import gg.xp.xivsupport.gui.util.GuiUtil;
 import gg.xp.xivsupport.persistence.gui.BooleanSettingGui;
 import gg.xp.xivsupport.persistence.gui.HttpURISettingGui;

--- a/xivsupport/src/main/java/gg/xp/services/Handleable.java
+++ b/xivsupport/src/main/java/gg/xp/services/Handleable.java
@@ -1,0 +1,6 @@
+package gg.xp.services;
+
+public interface Handleable {
+	boolean isHandled();
+	void setHandled();
+}

--- a/xivsupport/src/main/java/gg/xp/services/ServiceDescriptor.java
+++ b/xivsupport/src/main/java/gg/xp/services/ServiceDescriptor.java
@@ -1,0 +1,42 @@
+package gg.xp.services;
+
+import gg.xp.xivsupport.gui.util.HasFriendlyName;
+
+public interface ServiceDescriptor extends HasFriendlyName {
+
+	String name();
+
+	String id();
+
+	default int priority() {
+		return 0;
+	}
+
+	@Override
+	default String getFriendlyName() {
+		return name();
+	}
+
+	static ServiceDescriptor of(String id, String name) {
+		return of(id, name, 0);
+	}
+
+	static ServiceDescriptor of(String id, String name, int prio) {
+		return new ServiceDescriptor() {
+			@Override
+			public String name() {
+				return name;
+			}
+
+			@Override
+			public String id() {
+				return id;
+			}
+
+			@Override
+			public int priority() {
+				return prio;
+			}
+		};
+	}
+}

--- a/xivsupport/src/main/java/gg/xp/services/ServiceHandle.java
+++ b/xivsupport/src/main/java/gg/xp/services/ServiceHandle.java
@@ -1,0 +1,17 @@
+package gg.xp.services;
+
+import gg.xp.xivsupport.gui.util.HasFriendlyName;
+
+public interface ServiceHandle extends HasFriendlyName {
+
+	boolean enabled();
+
+	void setEnabled();
+
+	ServiceDescriptor descriptor();
+
+	@Override
+	default String getFriendlyName() {
+		return descriptor().getFriendlyName();
+	};
+}

--- a/xivsupport/src/main/java/gg/xp/services/ServiceSelector.java
+++ b/xivsupport/src/main/java/gg/xp/services/ServiceSelector.java
@@ -1,0 +1,162 @@
+package gg.xp.services;
+
+import gg.xp.xivsupport.persistence.PersistenceProvider;
+import gg.xp.xivsupport.persistence.settings.ObservableSetting;
+import gg.xp.xivsupport.persistence.settings.Resettable;
+import gg.xp.xivsupport.persistence.settings.StringSetting;
+import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+public abstract class ServiceSelector extends ObservableSetting implements Resettable {
+
+	private static final Logger log = LoggerFactory.getLogger(ServiceSelector.class);
+	private final Object lock = new Object();
+	private final List<ServiceHandle> providers = new ArrayList<>();
+	private volatile ServiceHandle current;
+	private final StringSetting setting;
+	private static final String DEFAULT_MARKER = "";
+
+	protected ServiceSelector(StringSetting setting) {
+		this.setting = setting;
+		List<ServiceHandle> defaultOptions = defaultOptions();
+		if (defaultOptions.isEmpty()) {
+			throw new IllegalArgumentException("Must have a default option!");
+		}
+		providers.addAll(defaultOptions);
+		setting.addAndRunListener(this::recalc);
+	}
+
+	protected ServiceSelector(PersistenceProvider pers, String propStub) {
+		this(new StringSetting(pers, propStub + ".choice", DEFAULT_MARKER));
+	}
+
+	protected abstract String name();
+
+	protected List<ServiceHandle> defaultOptions() {
+		return List.of(makeHandle(new ServiceDescriptor() {
+			@Override
+			public String name() {
+				return "None/Other";
+			}
+
+			@Override
+			public String id() {
+				return "none";
+			}
+
+			@Override
+			public int priority() {
+				return defaultOptionPriority();
+			}
+		}));
+	}
+
+	/**
+	 * What priority the built-in default option should have.
+	 * <p>
+	 * Can be safely ignored if supplying custom defaults.
+	 *
+	 * @return The priority for the default "none/other" option.
+	 */
+	protected int defaultOptionPriority() {
+		return 10;
+	};
+
+	private void recalc() {
+		synchronized (lock) {
+			providers.sort(Comparator.comparing(provider -> -provider.descriptor().priority()));
+			current = getEffectiveOption();
+		}
+		notifyListeners();
+	}
+
+	public @Nullable ServiceHandle getExplicitlySelectedOption() {
+		synchronized (lock) {
+			String value = setting.get();
+			if (value == null || value.isBlank()) {
+				return null;
+			}
+			return providers.stream().filter(provider -> provider.descriptor().id().equals(value))
+					.findFirst()
+					.orElse(null);
+		}
+	}
+
+	public void setCurrent(@Nullable ServiceHandle serviceHandle) {
+		if (serviceHandle == null) {
+			log.info("{}: Service Provider De-Selected", name());
+		}
+		else {
+			log.info("{}: Service Provider Selected: ({}) {}", name(), serviceHandle.descriptor().id(), serviceHandle.descriptor().name());
+		}
+		setting.set(serviceHandle == null ? DEFAULT_MARKER : serviceHandle.descriptor().id());
+	}
+
+	public List<ServiceHandle> getOptions() {
+		synchronized (lock) {
+			return new ArrayList<>(providers);
+		}
+	}
+
+	public ServiceHandle register(ServiceDescriptor service) {
+		ServiceHandle handle = makeHandle(service);
+		synchronized (lock) {
+			log.info("{}: Service Provider Registered: ({}) {}", name(), service.id(), service.name());
+			providers.add(handle);
+			recalc();
+		}
+		return handle;
+	}
+
+	protected ServiceHandle makeHandle(ServiceDescriptor service) {
+		return new ServiceHandle() {
+			@Override
+			public boolean enabled() {
+				return current == this;
+			}
+
+			@Override
+			public void setEnabled() {
+				setCurrent(this);
+			}
+
+			@Override
+			public ServiceDescriptor descriptor() {
+				return service;
+			}
+		};
+	}
+
+
+	public ServiceHandle defaultOption() {
+		synchronized (lock) {
+			recalc();
+			return providers.get(0);
+		}
+	}
+
+	@Override
+	public void delete() {
+		setCurrent(null);
+	}
+
+	@Override
+	public boolean isSet() {
+		return getExplicitlySelectedOption() != null;
+	}
+
+	public ServiceHandle getEffectiveOption() {
+		ServiceHandle selected = getExplicitlySelectedOption();
+		if (selected == null) {
+			return providers.get(0);
+		}
+		else {
+			return selected;
+		}
+	}
+}

--- a/xivsupport/src/main/java/gg/xp/services/ServiceSelectorGui.java
+++ b/xivsupport/src/main/java/gg/xp/services/ServiceSelectorGui.java
@@ -1,0 +1,131 @@
+package gg.xp.services;
+
+import gg.xp.xivsupport.gui.lists.FriendlyNameListCellRenderer;
+import gg.xp.xivsupport.gui.util.HasFriendlyName;
+import gg.xp.xivsupport.persistence.gui.EnumSettingGui;
+import gg.xp.xivsupport.persistence.settings.ResetMenuOption;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.swing.*;
+import javax.swing.event.ListDataListener;
+import java.awt.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Supplier;
+
+public class ServiceSelectorGui {
+
+	private static final Logger log = LoggerFactory.getLogger(ServiceSelectorGui.class);
+
+	private final JComboBox<HasFriendlyName> comboBox;
+	private final JLabel label;
+	private final ServiceSelector setting;
+//	private volatile boolean ignoreChange;
+
+	public ServiceSelectorGui(ServiceSelector setting, String label, Supplier<Boolean> enabled, boolean listen) {
+		this.setting = setting;
+
+		comboBox = new JComboBox<>() {
+			@Override
+			public boolean isEnabled() {
+				return enabled.get();
+			}
+		};
+		comboBox.setModel(new ComboBoxModel<>() {
+
+			private final HasFriendlyName defaultItem = () -> "Default: %s".formatted(setting.defaultOption().getFriendlyName());
+
+			private List<HasFriendlyName> makeList() {
+				List<HasFriendlyName> items = new ArrayList<>();
+				items.add(defaultItem);
+				items.addAll(setting.getOptions());
+				return items;
+			}
+
+			@Override
+			public void setSelectedItem(Object item) {
+				if (item == defaultItem) {
+					setting.setCurrent(null);
+				}
+				else if (item instanceof ServiceHandle handle) {
+					handle.setEnabled();
+				}
+				else {
+					log.warn("Unknown item: {}", item);
+				}
+			}
+
+			@Override
+			public Object getSelectedItem() {
+				ServiceHandle selection = setting.getExplicitlySelectedOption();
+				if (selection == null) {
+					return defaultItem;
+				}
+				else {
+					return selection;
+				}
+			}
+
+			@Override
+			public int getSize() {
+				return makeList().size();
+			}
+
+			@Override
+			public HasFriendlyName getElementAt(int index) {
+				return makeList().get(index);
+			}
+
+			@Override
+			public void addListDataListener(ListDataListener l) {
+				// TODO: is this needed?
+			}
+
+			@Override
+			public void removeListDataListener(ListDataListener l) {
+				// TODO: is this needed?
+			}
+		});
+		comboBox.setRenderer(new FriendlyNameListCellRenderer());
+//		comboBox.setSelectedItem(setting.get());
+//		comboBox.addItemListener(event -> {
+//			log.info("{} {}", event.getStateChange(), event.getItem());
+//			if (event.getStateChange() == ItemEvent.SELECTED) {
+//				ignoreChange = true;
+//				setting.set((X) event.getItem());
+//				ignoreChange = false;
+//			}
+//		});
+		if (listen) {
+			setting.addListener(() -> {
+				comboBox.repaint();
+//				log.info("{} {}", ignoreChange, setting.get());
+//				if (!ignoreChange) {
+//					comboBox.setSelectedItem(setting.get());
+//				}
+			});
+		}
+		comboBox.setComponentPopupMenu(ResetMenuOption.resetOnlyMenu(setting, this::reset));
+		this.label = new JLabel(label);
+		this.label.setLabelFor(comboBox);
+	}
+
+	private void reset() {
+		setting.delete();
+		comboBox.repaint();
+	}
+
+	public Component getComponent() {
+		JPanel panel = new JPanel();
+		panel.setLayout(new FlowLayout(FlowLayout.LEFT, 5, 0));
+		panel.add(label);
+		panel.add(comboBox);
+		return panel;
+	}
+
+	public JComboBox<HasFriendlyName> getComboBoxOnly() {
+		return comboBox;
+	}
+
+}

--- a/xivsupport/src/main/java/gg/xp/xivsupport/events/state/XivState.java
+++ b/xivsupport/src/main/java/gg/xp/xivsupport/events/state/XivState.java
@@ -57,6 +57,12 @@ public interface XivState extends SubState {
 	// TODO: does this still need to be a copy?
 	List<XivCombatant> getCombatantsListCopy();
 
+	/**
+	 * Returns the party slot of the given entity
+	 *
+	 * @param entity The entity
+	 * @return 0-7 based on their party slot, or -1 if they are not in the party
+	 */
 	int getPartySlotOf(XivEntity entity);
 
 	void provideCombatantHP(XivCombatant target, @NotNull HitPoints hitPoints);

--- a/xivsupport/src/main/java/gg/xp/xivsupport/events/triggers/marks/AutoMarkHandler.java
+++ b/xivsupport/src/main/java/gg/xp/xivsupport/events/triggers/marks/AutoMarkHandler.java
@@ -36,6 +36,7 @@ public class AutoMarkHandler {
 		this.state = state;
 	}
 
+	@Deprecated
 	public BooleanSetting getUseTelesto() {
 		return useTelesto;
 	}

--- a/xivsupport/src/main/java/gg/xp/xivsupport/events/triggers/marks/AutoMarkRequest.java
+++ b/xivsupport/src/main/java/gg/xp/xivsupport/events/triggers/marks/AutoMarkRequest.java
@@ -1,6 +1,7 @@
 package gg.xp.xivsupport.events.triggers.marks;
 
 import gg.xp.reevent.events.BaseEvent;
+import gg.xp.services.Handleable;
 import gg.xp.xivsupport.events.actlines.events.HasPrimaryValue;
 import gg.xp.xivsupport.events.actlines.events.HasTargetEntity;
 import gg.xp.xivsupport.models.XivCombatant;
@@ -8,11 +9,12 @@ import gg.xp.xivsupport.models.XivPlayerCharacter;
 
 import java.io.Serial;
 
-public class AutoMarkRequest extends BaseEvent implements HasTargetEntity {
+public class AutoMarkRequest extends BaseEvent implements HasTargetEntity, Handleable {
 
 	@Serial
 	private static final long serialVersionUID = -915091489094353125L;
 	private final XivPlayerCharacter playerToMark;
+	private transient boolean handled;
 
 	public AutoMarkRequest(XivPlayerCharacter playerToMark) {
 		this.playerToMark = playerToMark;
@@ -32,5 +34,15 @@ public class AutoMarkRequest extends BaseEvent implements HasTargetEntity {
 		return "AutoMarkRequest{" +
 		       "playerToMark=" + playerToMark +
 		       '}';
+	}
+
+	@Override
+	public boolean isHandled() {
+		return handled;
+	}
+
+	@Override
+	public void setHandled() {
+		handled = true;
 	}
 }

--- a/xivsupport/src/main/java/gg/xp/xivsupport/events/triggers/marks/AutoMarkSlotRequest.java
+++ b/xivsupport/src/main/java/gg/xp/xivsupport/events/triggers/marks/AutoMarkSlotRequest.java
@@ -1,15 +1,17 @@
 package gg.xp.xivsupport.events.triggers.marks;
 
 import gg.xp.reevent.events.BaseEvent;
+import gg.xp.services.Handleable;
 import gg.xp.xivsupport.events.actlines.events.HasPrimaryValue;
 
 import java.io.Serial;
 
-public class AutoMarkSlotRequest extends BaseEvent implements HasPrimaryValue {
+public class AutoMarkSlotRequest extends BaseEvent implements HasPrimaryValue, Handleable {
 
 	@Serial
 	private static final long serialVersionUID = 792969414398476188L;
 	private final int slotToMark;
+	private transient boolean handled;
 
 	public AutoMarkSlotRequest(int slotToMark) {
 		if (slotToMark >= 1 && slotToMark <= 8) {
@@ -34,5 +36,15 @@ public class AutoMarkSlotRequest extends BaseEvent implements HasPrimaryValue {
 		return "AutoMarkSlotRequest{" +
 		       "slotToMark=" + slotToMark +
 		       '}';
+	}
+
+	@Override
+	public boolean isHandled() {
+		return handled;
+	}
+
+	@Override
+	public void setHandled() {
+		handled = true;
 	}
 }

--- a/xivsupport/src/main/java/gg/xp/xivsupport/events/triggers/marks/ClearAutoMarkRequest.java
+++ b/xivsupport/src/main/java/gg/xp/xivsupport/events/triggers/marks/ClearAutoMarkRequest.java
@@ -1,10 +1,22 @@
 package gg.xp.xivsupport.events.triggers.marks;
 
 import gg.xp.reevent.events.BaseEvent;
+import gg.xp.services.Handleable;
 
 import java.io.Serial;
 
-public class ClearAutoMarkRequest extends BaseEvent {
+public class ClearAutoMarkRequest extends BaseEvent implements Handleable {
 	@Serial
 	private static final long serialVersionUID = 3326915962958188606L;
+	private transient boolean handled;
+
+	@Override
+	public boolean isHandled() {
+		return handled;
+	}
+
+	@Override
+	public void setHandled() {
+		handled = true;
+	}
 }

--- a/xivsupport/src/main/java/gg/xp/xivsupport/events/triggers/marks/adv/AutoMarkServiceSelector.java
+++ b/xivsupport/src/main/java/gg/xp/xivsupport/events/triggers/marks/adv/AutoMarkServiceSelector.java
@@ -1,0 +1,22 @@
+package gg.xp.xivsupport.events.triggers.marks.adv;
+
+import gg.xp.reevent.scan.ScanMe;
+import gg.xp.services.ServiceSelector;
+import gg.xp.xivsupport.events.triggers.marks.AutoMarkHandler;
+import gg.xp.xivsupport.persistence.PersistenceProvider;
+
+@ScanMe
+public class AutoMarkServiceSelector extends ServiceSelector {
+
+	private final AutoMarkHandler handler;
+
+	public AutoMarkServiceSelector(PersistenceProvider pers, AutoMarkHandler handler) {
+		super(pers, "automarks.service-selector");
+		this.handler = handler;
+	}
+
+	@Override
+	protected String name() {
+		return "AutoMarks";
+	}
+}

--- a/xivsupport/src/main/java/gg/xp/xivsupport/events/triggers/marks/adv/SpecificAutoMarkHandler.java
+++ b/xivsupport/src/main/java/gg/xp/xivsupport/events/triggers/marks/adv/SpecificAutoMarkHandler.java
@@ -5,7 +5,6 @@ import gg.xp.reevent.scan.HandleEvents;
 import gg.xp.xivsupport.events.debug.DebugCommand;
 import gg.xp.xivsupport.events.state.XivState;
 import gg.xp.xivsupport.models.XivPlayerCharacter;
-import gg.xp.xivsupport.persistence.PersistenceProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -26,16 +25,22 @@ public class SpecificAutoMarkHandler {
 	@HandleEvents
 	public void amTest(EventContext context, DebugCommand event) {
 		if (event.getCommand().equals("samtest")) {
-
 			List<String> args = event.getArgs();
 			if (args.size() != 3) {
 				log.error("Wrong number of arguments. Syntax: samtest MARKER_TYPE PARTY_SLOT");
 				return;
 			}
-
 			int slot = Integer.parseInt(args.get(2));
+			XivPlayerCharacter playerToMark;
+			try {
+				playerToMark = state.getPartyList().get(slot - 1);
+			}
+			catch (IndexOutOfBoundsException e) {
+				log.error("Tried to mark slot {} but there were only {} party members.", slot, state.getPartyList().size());
+				return;
+			}
 			MarkerSign marker = MarkerSign.of(args.get(1));
-			context.accept(new SpecificAutoMarkSlotRequest(slot, marker));
+			context.accept(new SpecificAutoMarkRequest(playerToMark, marker));
 		}
 	}
 

--- a/xivsupport/src/main/java/gg/xp/xivsupport/events/triggers/marks/adv/SpecificAutoMarkRequest.java
+++ b/xivsupport/src/main/java/gg/xp/xivsupport/events/triggers/marks/adv/SpecificAutoMarkRequest.java
@@ -1,6 +1,7 @@
 package gg.xp.xivsupport.events.triggers.marks.adv;
 
 import gg.xp.reevent.events.BaseEvent;
+import gg.xp.services.Handleable;
 import gg.xp.xivsupport.events.actlines.events.HasPlayerHeadMarker;
 import gg.xp.xivsupport.events.actlines.events.HasPrimaryValue;
 import gg.xp.xivsupport.events.actlines.events.HasTargetEntity;
@@ -10,12 +11,13 @@ import org.jetbrains.annotations.Nullable;
 
 import java.io.Serial;
 
-public class SpecificAutoMarkRequest extends BaseEvent implements HasPrimaryValue, HasTargetEntity, HasPlayerHeadMarker {
+public class SpecificAutoMarkRequest extends BaseEvent implements HasPrimaryValue, HasTargetEntity, HasPlayerHeadMarker, Handleable {
 
 	@Serial
 	private static final long serialVersionUID = -1398496564300407615L;
 	private final XivPlayerCharacter playerToMark;
 	private final MarkerSign marker;
+	private transient boolean handled;
 
 	public SpecificAutoMarkRequest(XivPlayerCharacter playerToMark, MarkerSign marker) {
 		this.playerToMark = playerToMark;
@@ -52,5 +54,15 @@ public class SpecificAutoMarkRequest extends BaseEvent implements HasPrimaryValu
 		       "playerToMark=" + playerToMark +
 		       ", marker=" + marker +
 		       '}';
+	}
+
+	@Override
+	public boolean isHandled() {
+		return handled;
+	}
+
+	@Override
+	public void setHandled() {
+		handled = true;
 	}
 }

--- a/xivsupport/src/main/java/gg/xp/xivsupport/events/triggers/marks/adv/SpecificAutoMarkSlotRequest.java
+++ b/xivsupport/src/main/java/gg/xp/xivsupport/events/triggers/marks/adv/SpecificAutoMarkSlotRequest.java
@@ -1,18 +1,20 @@
 package gg.xp.xivsupport.events.triggers.marks.adv;
 
 import gg.xp.reevent.events.BaseEvent;
+import gg.xp.services.Handleable;
 import gg.xp.xivsupport.events.actlines.events.HasPlayerHeadMarker;
 import gg.xp.xivsupport.events.actlines.events.HasPrimaryValue;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.Serial;
 
-public class SpecificAutoMarkSlotRequest extends BaseEvent implements HasPrimaryValue, HasPlayerHeadMarker {
+public class SpecificAutoMarkSlotRequest extends BaseEvent implements HasPrimaryValue, HasPlayerHeadMarker, Handleable {
 
 	@Serial
 	private static final long serialVersionUID = 792969414398476188L;
 	private final int slotToMark;
 	private final MarkerSign marker;
+	private transient boolean handled;
 
 	public SpecificAutoMarkSlotRequest(int slotToMark, MarkerSign marker) {
 		this.marker = marker;
@@ -49,5 +51,15 @@ public class SpecificAutoMarkSlotRequest extends BaseEvent implements HasPrimary
 		       "slotToMark=" + slotToMark +
 		       ", marker=" + marker +
 		       '}';
+	}
+
+	@Override
+	public boolean isHandled() {
+		return handled;
+	}
+
+	@Override
+	public void setHandled() {
+		handled = true;
 	}
 }

--- a/xivsupport/src/main/java/gg/xp/xivsupport/events/triggers/marks/gui/AutoMarkGui.java
+++ b/xivsupport/src/main/java/gg/xp/xivsupport/events/triggers/marks/gui/AutoMarkGui.java
@@ -1,8 +1,10 @@
 package gg.xp.xivsupport.events.triggers.marks.gui;
 
 import gg.xp.reevent.scan.ScanMe;
+import gg.xp.services.ServiceSelectorGui;
 import gg.xp.xivsupport.events.triggers.marks.AutoMarkHandler;
 import gg.xp.xivsupport.events.triggers.marks.AutoMarkKeyHandler;
+import gg.xp.xivsupport.events.triggers.marks.adv.AutoMarkServiceSelector;
 import gg.xp.xivsupport.gui.TitleBorderFullsizePanel;
 import gg.xp.xivsupport.gui.components.ReadOnlyText;
 import gg.xp.xivsupport.gui.extra.PluginTab;
@@ -19,10 +21,12 @@ public class AutoMarkGui implements PluginTab {
 
 	private final AutoMarkHandler marks;
 	private final AutoMarkKeyHandler keyHandler;
+	private final AutoMarkServiceSelector serv;
 
-	public AutoMarkGui(AutoMarkHandler marks, AutoMarkKeyHandler keyHandler) {
+	public AutoMarkGui(AutoMarkHandler marks, AutoMarkKeyHandler keyHandler, AutoMarkServiceSelector serv) {
 		this.marks = marks;
 		this.keyHandler = keyHandler;
+		this.serv = serv;
 	}
 
 	@Override
@@ -41,17 +45,15 @@ public class AutoMarkGui implements PluginTab {
 		macroHelpButton.addActionListener(l -> {
 			JOptionPane.showMessageDialog(SwingUtilities.getRoot(macroHelpButton), macroHelpText);
 		});
-		BooleanSetting telestoSetting = marks.getUseTelesto();
-		Component useTelesto = new BooleanSettingGui(telestoSetting, "Use Telesto instead of Macros (must be installed in Dalamud)").getComponent();
-//		Component krMode = new BooleanSettingGui(marks.getKoreanMode(), "JP/KR Client Mode (changes 'ignore' to 'stop')").getComponent();
+		Component serviceSelectorLabel = new JLabel("AutoMark System:");
+		Component serviceSelector = new ServiceSelectorGui(serv, "", () -> true, true).getComboBoxOnly();
+		serv.addListener(outer::repaint);
 		Component langMode = new EnumSettingGui<>(marks.getLanguageSetting(), "Game Client Language", () -> true).getComponent();
-		Component useFKeys = new BooleanSettingGui(keyHandler.getUseFkeys(), "Use F1-F9 (Instead of NumPad 1-9)", () -> !telestoSetting.get()).getComponent();
-		telestoSetting.addListener(outer::repaint);
+		Component useFKeys = new BooleanSettingGui(keyHandler.getUseFkeys(), "For Macros Only: Use F1-F9 (Instead of NumPad 1-9)", () -> keyHandler.getHandle().enabled()).getComponent();
 
-		ReadOnlyText text = new ReadOnlyText("Note: Telesto is REQUIRED for triggers that place specific markers (rather than just doing '/mk attack' such as Titan Jails)");
-//		text.setPreferredSize(new Dimension(400, 400));
+		ReadOnlyText text = new ReadOnlyText("Note: PostNamazu or Telesto is REQUIRED for triggers that place specific markers (rather than just doing '/mk attack' such as Titan Jails)");
 
-		GuiUtil.simpleTopDownLayout(outer, 400, helpButton, macroHelpButton, useTelesto, langMode, useFKeys, text);
+		GuiUtil.simpleTopDownLayout(outer, 400, helpButton, macroHelpButton, serviceSelectorLabel, serviceSelector, langMode, useFKeys, text);
 
 		return outer;
 	}

--- a/xivsupport/src/main/java/gg/xp/xivsupport/persistence/gui/HttpURISettingGui.java
+++ b/xivsupport/src/main/java/gg/xp/xivsupport/persistence/gui/HttpURISettingGui.java
@@ -2,8 +2,8 @@ package gg.xp.xivsupport.persistence.gui;
 
 import gg.xp.xivsupport.gui.WrapLayout;
 import gg.xp.xivsupport.gui.tables.filters.TextFieldWithValidation;
-import gg.xp.xivsupport.persistence.settings.ResetMenuOption;
 import gg.xp.xivsupport.persistence.settings.HttpURISetting;
+import gg.xp.xivsupport.persistence.settings.ResetMenuOption;
 
 import javax.swing.*;
 import java.awt.*;
@@ -27,7 +27,7 @@ public class HttpURISettingGui {
 				return uri;
 			}
 			else {
-				throw new IllegalArgumentException("Protocol must be WS or WSS");
+				throw new IllegalArgumentException("Protocol must be HTTP or HTTPS");
 			}
 		}, this::setNewValue, setting.get().toString());
 		textBox.setColumns(20);
@@ -66,6 +66,7 @@ public class HttpURISettingGui {
 
 	public Component getResetButton() {
 		JButton jButton = new JButton("Reset");
+		jButton.setMargin(new Insets(3, 8, 3, 8));
 		jButton.addActionListener(l -> {
 			// TODO: Kind of bad
 			textBox.setText(setting.getDefault().toString());

--- a/xivsupport/src/test/java/gg/xp/services/ServiceTest.java
+++ b/xivsupport/src/test/java/gg/xp/services/ServiceTest.java
@@ -1,0 +1,102 @@
+package gg.xp.services;
+
+import gg.xp.xivsupport.persistence.InMemoryMapPersistenceProvider;
+import gg.xp.xivsupport.persistence.settings.StringSetting;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.List;
+
+public class ServiceTest {
+
+	private static final class TestService extends ServiceSelector {
+
+		protected TestService(StringSetting setting) {
+			super(setting);
+		}
+
+		@Override
+		protected String name() {
+			return "Test Service";
+		}
+
+		@Override
+		protected int defaultOptionPriority() {
+			return 5;
+		}
+	}
+
+	@Test
+	void doTheTest() {
+		InMemoryMapPersistenceProvider pers = new InMemoryMapPersistenceProvider();
+		StringSetting setting = new StringSetting(pers, "my-setting", null);
+		TestService serv = new TestService(setting);
+		{
+			List<ServiceHandle> options = serv.getOptions();
+			MatcherAssert.assertThat(options, Matchers.hasSize(1));
+			ServiceHandle defaultOpt = options.get(0);
+			Assert.assertTrue(defaultOpt.enabled());
+		}
+		ServiceHandle hand0 = serv.getOptions().get(0);
+		// Register something with higher priority than the default, should switch over automatically
+		ServiceDescriptor desc1 = new ServiceDescriptor() {
+			@Override
+			public String name() {
+				return "Service 1";
+			}
+
+			@Override
+			public String id() {
+				return "serv1";
+			}
+
+			@Override
+			public int priority() {
+				return 9;
+			}
+		};
+		ServiceHandle hand1 = serv.register(desc1);
+		Assert.assertFalse(hand0.enabled());
+		Assert.assertTrue(hand1.enabled());
+
+		// Register something with even higher priority than the previous option, should switch
+		ServiceDescriptor desc2 = new ServiceDescriptor() {
+			@Override
+			public String name() {
+				return "Service 2";
+			}
+
+			@Override
+			public String id() {
+				return "serv2";
+			}
+
+			@Override
+			public int priority() {
+				return 11;
+			}
+		};
+		ServiceHandle hand2 = serv.register(desc2);
+		Assert.assertFalse(hand0.enabled());
+		Assert.assertFalse(hand1.enabled());
+		Assert.assertTrue(hand2.enabled());
+
+		hand1.setEnabled();
+		Assert.assertFalse(hand0.enabled());
+		Assert.assertTrue(hand1.enabled());
+		Assert.assertFalse(hand2.enabled());
+
+		hand0.setEnabled();
+		Assert.assertTrue(hand0.enabled());
+		Assert.assertFalse(hand1.enabled());
+		Assert.assertFalse(hand2.enabled());
+
+		serv.delete();
+		Assert.assertFalse(hand0.enabled());
+		Assert.assertFalse(hand1.enabled());
+		Assert.assertTrue(hand2.enabled());
+	}
+
+}


### PR DESCRIPTION
Beginning of support for [PostNamazu](https://github.com/Natsukage/PostNamazu/). This provides even more reliable automarkers, because it can directly mark an entity by ID, rather than needing to resolve to a party list slot first.

While not supported *yet*, this also means that potentially, enemies and non-party players can also be marked.

In order to use this, you'll need to install PostNamazu (it is an ACT plugin), and then click these two things:

![image](https://user-images.githubusercontent.com/14287379/226780127-4b49538e-aefe-4d08-b38e-36a2c5e4811e.png)

Leave the port as the default since the configuration UI doesn't exist yet.

![image](https://user-images.githubusercontent.com/14287379/226779534-8bc2c6ed-0e54-44ac-9d52-11f2f9e4096e.png)

The Automarks tab now has a dropdown rather than a simple checkbox. It will default to Telesto if you previously were using it for automarks.