### PR TITLE
Support for putting cooldowns on a timeline via a replay

### DIFF
--- a/reevent/src/main/java/gg/xp/reevent/scan/AutoHandler.java
+++ b/reevent/src/main/java/gg/xp/reevent/scan/AutoHandler.java
@@ -10,6 +10,7 @@ import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
+@Deprecated
 public class AutoHandler implements TypedEventHandler<Event> {
 
 	private static final Logger log = LoggerFactory.getLogger(AutoHandler.class);

--- a/reevent/src/main/java/gg/xp/reevent/scan/AutoScan.java
+++ b/reevent/src/main/java/gg/xp/reevent/scan/AutoScan.java
@@ -137,7 +137,7 @@ public class AutoScan {
 
 		Map<Class<?>, List<Method>> classMethodMap = new LinkedHashMap<>();
 		for (Class<?> annotatedClass : annotatedClasses) {
-			if (isClassInstantiable(annotatedClass)) {
+			if (isClassInstantiable(annotatedClass) && !annotatedClass.isAnnotationPresent(NoAutoScan.class)) {
 				classMethodMap.computeIfAbsent(annotatedClass, unused -> new ArrayList<>());
 			}
 			else {
@@ -164,6 +164,7 @@ public class AutoScan {
 			//noinspection SimplifyForEach
 			Stream.concat(Stream.of(clazz), implementingClasses.stream())
 					.filter(AutoScan::isClassInstantiable)
+					.filter(c -> !c.isAnnotationPresent(NoAutoScan.class))
 					.forEach(cls -> classMethodMap.computeIfAbsent(cls, unused -> new ArrayList<>()).add(method));
 		}
 		log.info("Methods: {}", methodCount);

--- a/reevent/src/main/java/gg/xp/reevent/scan/NoAutoScan.java
+++ b/reevent/src/main/java/gg/xp/reevent/scan/NoAutoScan.java
@@ -4,9 +4,9 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 
 /**
- * Causes the annotated class to be scanned by {@link AutoHandlerScan} even if it does not have any annotations
+ * Causes the annotated class to NOT be scanned by {@link AutoHandlerScan} even if it does have annotations
  * that would otherwise cause it to be scanned.
  */
 @Retention(RetentionPolicy.RUNTIME)
-public @interface ScanMe {
+public @interface NoAutoScan {
 }

--- a/timelines/src/main/java/gg/xp/xivsupport/timelines/CustomTimelineEntry.java
+++ b/timelines/src/main/java/gg/xp/xivsupport/timelines/CustomTimelineEntry.java
@@ -33,6 +33,7 @@ public class CustomTimelineEntry implements CustomTimelineItem, Serializable {
 	public @Nullable Double windowEnd;
 	public @Nullable Double jump;
 	public @Nullable String jumpLabel;
+	public @Nullable String importSource;
 	public boolean forceJump;
 	// TODO: this uses the absolute path to the JAR, which means icons will break if the user moves their install location.
 	// Best solution is to probably make our own little class that lets you specify an ability/status ID in addition to
@@ -61,9 +62,10 @@ public class CustomTimelineEntry implements CustomTimelineItem, Serializable {
 			@Nullable Boolean forceJump,
 			@Nullable URL icon,
 			@Nullable TimelineReference replaces,
-			 boolean disabled,
-			 boolean callout,
-			 double calloutPreTime
+			boolean disabled,
+			boolean callout,
+			double calloutPreTime,
+			@Nullable String importSource
 	) {
 		// TODO: this wouldn't be a bad place to do the JAR url correction. Perhaps not the cleanest way,
 		// but it works.
@@ -82,6 +84,7 @@ public class CustomTimelineEntry implements CustomTimelineItem, Serializable {
 		this.icon = icon;
 		this.replaces = replaces;
 		this.enabled = !disabled;
+		this.importSource = importSource;
 	}
 
 	@JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
@@ -98,6 +101,7 @@ public class CustomTimelineEntry implements CustomTimelineItem, Serializable {
 			@JsonProperty("icon") @Nullable URL icon,
 			@JsonProperty("replaces") @Nullable TimelineReference replaces,
 			@JsonProperty(value = "disabled", defaultValue = "false") boolean disabled,
+			@JsonProperty(value = "importSource") String importSource,
 			@JsonProperty(value = "callout", defaultValue = "false") boolean callout,
 			@JsonProperty(value = "calloutPreTime", defaultValue = "0") double calloutPreTime,
 			@JsonProperty("jobs") @Nullable CombatJobSelection jobs
@@ -120,6 +124,7 @@ public class CustomTimelineEntry implements CustomTimelineItem, Serializable {
 		this.enabled = !disabled;
 		this.enabledJobs = jobs == null ? CombatJobSelection.all() : jobs;
 		this.esc = esc;
+		this.importSource = importSource;
 	}
 
 	@Override
@@ -270,7 +275,8 @@ public class CustomTimelineEntry implements CustomTimelineItem, Serializable {
 				TimelineReference.of(other),
 				false,
 				false,
-				0
+				0,
+				null
 		);
 		newCte.enabledJobs = jobSelFor(other);
 		return newCte;
@@ -292,7 +298,8 @@ public class CustomTimelineEntry implements CustomTimelineItem, Serializable {
 				null,
 				false,
 				other.callout(),
-				other.calloutPreTime()
+				other.calloutPreTime(),
+				null
 		);
 		newCte.enabledJobs = jobSelFor(other);
 		return newCte;
@@ -330,5 +337,10 @@ public class CustomTimelineEntry implements CustomTimelineItem, Serializable {
 	public @Nullable CombatJobSelection getEnabledJobs() {
 		// Don't bother serializing if every job is selected
 		return enabledJobs.isEnabledForAll() ? null : enabledJobs;
+	}
+
+	@Override
+	public @Nullable String getImportSource() {
+		return importSource;
 	}
 }

--- a/timelines/src/main/java/gg/xp/xivsupport/timelines/TimelineEntry.java
+++ b/timelines/src/main/java/gg/xp/xivsupport/timelines/TimelineEntry.java
@@ -1,6 +1,8 @@
 package gg.xp.xivsupport.timelines;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import gg.xp.reevent.events.Event;
 import gg.xp.xivdata.data.*;
 import org.jetbrains.annotations.NotNull;
@@ -398,5 +400,16 @@ public interface TimelineEntry extends Comparable<TimelineEntry> {
 							alertText: "%s",
 						},
 				""", uniqueName, uniqueName, calloutPreTime(), callTextForExport());
+	}
+
+	@JsonProperty
+	@JsonInclude(JsonInclude.Include.NON_DEFAULT)
+	default @Nullable String getImportSource() {
+		return null;
+	};
+
+	@JsonIgnore
+	default boolean isImported() {
+		return getImportSource() != null;
 	}
 }

--- a/timelines/src/main/java/gg/xp/xivsupport/timelines/TimelineEntry.java
+++ b/timelines/src/main/java/gg/xp/xivsupport/timelines/TimelineEntry.java
@@ -1,6 +1,7 @@
 package gg.xp.xivsupport.timelines;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import gg.xp.reevent.events.Event;
@@ -17,6 +18,7 @@ import java.util.stream.Stream;
 /**
  * Base interface for a timeline entry
  */
+@JsonIgnoreProperties("imported")
 public interface TimelineEntry extends Comparable<TimelineEntry> {
 
 	/**

--- a/timelines/src/main/java/gg/xp/xivsupport/timelines/gui/TimelineRecordingPopup.java
+++ b/timelines/src/main/java/gg/xp/xivsupport/timelines/gui/TimelineRecordingPopup.java
@@ -1,0 +1,261 @@
+package gg.xp.xivsupport.timelines.gui;
+
+import gg.xp.reevent.scan.HandleEvents;
+import gg.xp.reevent.scan.NoAutoScan;
+import gg.xp.xivdata.data.*;
+import gg.xp.xivdata.data.duties.*;
+import gg.xp.xivsupport.cdsupport.CustomCooldownManager;
+import gg.xp.xivsupport.cdsupport.CustomCooldownsUpdated;
+import gg.xp.xivsupport.events.actlines.events.AbilityUsedEvent;
+import gg.xp.xivsupport.events.actlines.events.ZoneChangeEvent;
+import gg.xp.xivsupport.events.misc.pulls.PullEndedEvent;
+import gg.xp.xivsupport.events.state.XivState;
+import gg.xp.xivsupport.gui.util.EasyAction;
+import gg.xp.xivsupport.models.XivZone;
+import gg.xp.xivsupport.replay.ReplayController;
+import gg.xp.xivsupport.sys.Threading;
+import gg.xp.xivsupport.timelines.CustomTimelineEntry;
+import gg.xp.xivsupport.timelines.CustomTimelineItem;
+import gg.xp.xivsupport.timelines.TimelineCustomizations;
+import gg.xp.xivsupport.timelines.TimelineInfo;
+import gg.xp.xivsupport.timelines.TimelineManager;
+import gg.xp.xivsupport.timelines.TimelineProcessor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.swing.*;
+import java.awt.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+@NoAutoScan
+public class TimelineRecordingPopup extends JDialog {
+
+	private static final Logger log = LoggerFactory.getLogger(TimelineRecordingPopup.class);
+	private static final ExecutorService exs = Executors.newCachedThreadPool(Threading.namedDaemonThreadFactory("TimelineRecordingPopup"));
+	public static final String IMPORT_SOURCE = "Timeline Recorder";
+
+	private final TimelineManager mgr;
+	private final TimelinesTab tab;
+	private final ReplayController replay;
+	private final XivState state;
+	private final CustomCooldownManager cdm;
+	private final JLabel statusLabel;
+	private Map<Long, ExtendedCooldownDescriptor> cdMap;
+	private volatile boolean isInTlZone;
+	private volatile boolean recording;
+	private List<Entry> entries;
+	private JButton runButton;
+	private JButton closeButton;
+	private JButton acceptButton;
+	private XivZone zone;
+
+	public TimelineRecordingPopup(TimelineManager mgr, TimelinesTab tab, ReplayController replay, XivState state, CustomCooldownManager cdm) {
+		super(SwingUtilities.getWindowAncestor(tab), "Timeline Recording");
+		this.mgr = mgr;
+		this.tab = tab;
+		this.replay = replay;
+		this.state = state;
+		this.cdm = cdm;
+		this.statusLabel = new JLabel("...");
+		processZoneChange();
+		processCdChange();
+		setupGui();
+		reset();
+		setLocationRelativeTo(tab);
+	}
+
+	private void setupGui() {
+		JPanel content = new JPanel();
+		content.setLayout(new BorderLayout());
+		content.add(statusLabel, BorderLayout.CENTER);
+
+		JPanel buttons = new JPanel();
+		buttons.setLayout(new BoxLayout(buttons, BoxLayout.X_AXIS));
+
+		acceptButton = new JButton("Accept");
+		acceptButton.addActionListener(l -> this.finish());
+		buttons.add(acceptButton);
+		acceptButton.setEnabled(false);
+		runButton = new JButton("Run");
+		runButton.addActionListener(l -> exs.submit(this::start));
+		buttons.add(runButton);
+		closeButton = new EasyAction("Close", () -> setVisible(false)).asButton();
+		buttons.add(closeButton);
+
+		content.add(buttons, BorderLayout.SOUTH);
+		content.setPreferredSize(new Dimension(400, 200));
+		setContentPane(content);
+		setDefaultCloseOperation(HIDE_ON_CLOSE);
+		pack();
+
+	}
+
+	private void finalizeEntries(XivZone zone, List<Entry> entries) {
+		TimelineCustomizations cs = mgr.getCustomSettings(zone.getId());
+		List<CustomTimelineItem> allEntries = new ArrayList<>(cs.getEntries().stream().filter(ti -> !IMPORT_SOURCE.equals(ti.getImportSource())).toList());
+		entries.forEach(entry -> {
+			CustomTimelineEntry newEntry = new CustomTimelineEntry();
+			newEntry.importSource = IMPORT_SOURCE;
+			newEntry.time = entry.time;
+			newEntry.name = entry.event.getAbility().getName();
+			ActionIcon icon = ActionLibrary.iconForId(entry.event.getAbility().getId());
+			CombatJobSelection jobSel = CombatJobSelection.all();
+			if (icon != null) {
+				newEntry.icon = icon.getIconUrl();
+			}
+			Job job = entry.cd.getJob();
+			JobType jobType = entry.cd.getJobType();
+			if (job != null) {
+				jobSel.setEnabledForAll(false);
+				jobSel.changeJobState(job, true);
+			}
+			else if (jobType != null) {
+				jobSel.setEnabledForAll(false);
+				jobSel.changeCategoryState(jobType, true);
+			}
+			newEntry.enabledJobs = jobSel;
+			allEntries.add(newEntry);
+		});
+		cs.setEntries(allEntries);
+		mgr.commitCustomSettings(zone.getId());
+		tab.selectZone(zone.getId());
+		tab.refresh();
+	}
+
+	private void finish() {
+		List<Entry> entries = new ArrayList<>(this.entries);
+		exs.submit(() -> finalizeEntries(this.zone, entries));
+		setVisible(false);
+		reset();
+	}
+
+	@Override
+	public void setVisible(boolean b) {
+		super.setVisible(b);
+	}
+
+	private void setStatusLabel(String newStatus) {
+		statusLabel.setText(newStatus);
+	}
+
+	@HandleEvents
+	public void zoneChange(ZoneChangeEvent zce) {
+		processZoneChange();
+	}
+
+	private void processZoneChange() {
+		XivZone zone = state.getZone();
+		if (zone == null) {
+			isInTlZone = false;
+		}
+		else {
+			isInTlZone = mgr.getTimeline(zone.getId()) != null;
+		}
+	}
+
+	@HandleEvents
+	public void cdChange(CustomCooldownsUpdated event) {
+		processCdChange();
+	}
+
+	private void processCdChange() {
+		Map<Long, ExtendedCooldownDescriptor> cdIdMap = new HashMap<>();
+		for (ExtendedCooldownDescriptor cd : cdm.getAllCds()) {
+			Collection<Long> ids = cd.getAllRelevantAbilityIds();
+			ids.forEach(id -> cdIdMap.put(id, cd));
+		}
+		cdMap = cdIdMap;
+	}
+
+	@HandleEvents
+	public void pullEnd(PullEndedEvent event) {
+		log.info("Pull ended");
+		recording = false;
+	}
+
+	@HandleEvents
+	public void abilityUsed(AbilityUsedEvent event) {
+		if (!recording) {
+			return;
+		}
+		ExtendedCooldownDescriptor cd = cdMap.get(event.getAbility().getId());
+		if (cd != null && cd.abilityIdMatches(event.getAbility().getId())) {
+			log.info("CD used: {} -> {}", event.getAbility(), cd);
+			double time = mgr.getCurrentProcessor().getEffectiveTime();
+			entries.add(new Entry(time, cd, event));
+		}
+	}
+
+	private void reset() {
+		setStatusLabel("Click 'Run'");
+		entries = new ArrayList<>();
+		acceptButton.setEnabled(false);
+		runButton.setEnabled(true);
+		closeButton.setText("Close");
+		closeButton.setEnabled(true);
+		setDefaultCloseOperation(HIDE_ON_CLOSE);
+	}
+
+	private void start() {
+		// First, advance to the beginning of a valid zone
+		try {
+			setStatusLabel("Finding beginning of zone...");
+			replay.advanceByAsyncWhile(() -> !isInTlZone).get();
+			this.zone = state.getZone();
+			KnownDuty duty = KnownDuty.forZone(zone.getId());
+			TimelineInfo tlInfo = mgr.getInfoForZone(zone.getId());
+			TimelineProcessor tl = mgr.getTimeline(zone.getId());
+			StringBuilder confirmation = new StringBuilder("You are in zone ")
+					.append(zone.getId());
+			String zoneName = zone.getName();
+			if (!zoneName.equals(String.valueOf(zone.getId()))) {
+				confirmation
+						.append(" '")
+						.append(zone.getName())
+						.append('\'');
+			}
+
+			if (duty != null) {
+				confirmation.append(" (").append(duty.getName()).append(')');
+			}
+			confirmation.append('\n')
+					.append("The timeline file is ")
+					.append(tlInfo.filename());
+			confirmation.append("\nStart recording?");
+			setStatusLabel("...");
+			int result = JOptionPane.showConfirmDialog(this, confirmation.toString(), "Start Recording?", JOptionPane.YES_NO_OPTION);
+			if (result == JOptionPane.NO_OPTION) {
+				reset();
+				return;
+			}
+			tab.selectZone(zone.getId());
+			runButton.setEnabled(false);
+			closeButton.setEnabled(false);
+			setDefaultCloseOperation(DO_NOTHING_ON_CLOSE);
+			setStatusLabel("Recording...");
+			recording = true;
+			replay.advanceByAsyncWhile(() -> recording).get();
+			entries.forEach(e -> log.info("Entry: {}", e));
+			setStatusLabel("Done! Collected %s entries.".formatted(entries.size()));
+			acceptButton.setEnabled(true);
+			closeButton.setEnabled(true);
+			setDefaultCloseOperation(HIDE_ON_CLOSE);
+			closeButton.setText("Cancel");
+		}
+		catch (Throwable t) {
+			log.error("Error when replaying: ", t);
+			setStatusLabel("Error, see log");
+			throw new RuntimeException(t);
+		}
+	}
+
+	private record Entry(double time, ExtendedCooldownDescriptor cd, AbilityUsedEvent event) {
+	}
+
+}

--- a/timelines/src/main/java/gg/xp/xivsupport/timelines/gui/TimelineRecordingPopup.java
+++ b/timelines/src/main/java/gg/xp/xivsupport/timelines/gui/TimelineRecordingPopup.java
@@ -10,6 +10,7 @@ import gg.xp.xivsupport.events.actlines.events.AbilityUsedEvent;
 import gg.xp.xivsupport.events.actlines.events.ZoneChangeEvent;
 import gg.xp.xivsupport.events.misc.pulls.PullEndedEvent;
 import gg.xp.xivsupport.events.state.XivState;
+import gg.xp.xivsupport.gui.WrapLayout;
 import gg.xp.xivsupport.gui.util.EasyAction;
 import gg.xp.xivsupport.models.XivZone;
 import gg.xp.xivsupport.replay.ReplayController;
@@ -62,7 +63,7 @@ public class TimelineRecordingPopup extends JDialog {
 		this.replay = replay;
 		this.state = state;
 		this.cdm = cdm;
-		this.statusLabel = new JLabel("...");
+		this.statusLabel = new JLabel("...", SwingConstants.CENTER);
 		processZoneChange();
 		processCdChange();
 		setupGui();
@@ -76,7 +77,7 @@ public class TimelineRecordingPopup extends JDialog {
 		content.add(statusLabel, BorderLayout.CENTER);
 
 		JPanel buttons = new JPanel();
-		buttons.setLayout(new BoxLayout(buttons, BoxLayout.X_AXIS));
+		buttons.setLayout(new WrapLayout());
 
 		acceptButton = new JButton("Accept");
 		acceptButton.addActionListener(l -> this.finish());
@@ -85,11 +86,11 @@ public class TimelineRecordingPopup extends JDialog {
 		runButton = new JButton("Run");
 		runButton.addActionListener(l -> exs.submit(this::start));
 		buttons.add(runButton);
-		closeButton = new EasyAction("Close", () -> setVisible(false)).asButton();
+		closeButton = new EasyAction("Cancel", () -> setVisible(false)).asButton();
 		buttons.add(closeButton);
 
 		content.add(buttons, BorderLayout.SOUTH);
-		content.setPreferredSize(new Dimension(400, 200));
+		content.setPreferredSize(new Dimension(400, 75));
 		setContentPane(content);
 		setDefaultCloseOperation(HIDE_ON_CLOSE);
 		pack();
@@ -193,11 +194,10 @@ public class TimelineRecordingPopup extends JDialog {
 	}
 
 	private void reset() {
-		setStatusLabel("Click 'Run'");
+		setStatusLabel("Click 'Run' to start...");
 		entries = new ArrayList<>();
 		acceptButton.setEnabled(false);
 		runButton.setEnabled(true);
-		closeButton.setText("Close");
 		closeButton.setEnabled(true);
 		setDefaultCloseOperation(HIDE_ON_CLOSE);
 	}
@@ -246,7 +246,6 @@ public class TimelineRecordingPopup extends JDialog {
 			acceptButton.setEnabled(true);
 			closeButton.setEnabled(true);
 			setDefaultCloseOperation(HIDE_ON_CLOSE);
-			closeButton.setText("Cancel");
 		}
 		catch (Throwable t) {
 			log.error("Error when replaying: ", t);

--- a/xivdata/src/main/java/gg/xp/xivdata/data/duties/KnownDuty.java
+++ b/xivdata/src/main/java/gg/xp/xivdata/data/duties/KnownDuty.java
@@ -1,5 +1,6 @@
 package gg.xp.xivdata.data.duties;
 
+import gg.xp.xivdata.data.*;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Arrays;

--- a/xivsupport/src/main/java/gg/xp/xivsupport/cdsupport/CustomCooldownManager.java
+++ b/xivsupport/src/main/java/gg/xp/xivsupport/cdsupport/CustomCooldownManager.java
@@ -3,14 +3,17 @@ package gg.xp.xivsupport.cdsupport;
 import com.fasterxml.jackson.core.type.TypeReference;
 import gg.xp.reevent.events.EventMaster;
 import gg.xp.reevent.scan.ScanMe;
+import gg.xp.xivdata.data.*;
 import gg.xp.xivsupport.persistence.PersistenceProvider;
 import gg.xp.xivsupport.persistence.settings.CustomJsonListSetting;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Stream;
 
 @ScanMe
 public class CustomCooldownManager {
@@ -31,6 +34,10 @@ public class CustomCooldownManager {
 
 	public List<CustomCooldown> getCooldowns() {
 		return Collections.unmodifiableList(cds);
+	}
+
+	public List<ExtendedCooldownDescriptor> getAllCds() {
+		return Stream.concat(Arrays.stream(Cooldown.values()), getCooldowns().stream().map(CustomCooldown::buildCd)).toList();
 	}
 
 	public void addCooldown(CustomCooldown cooldown) {

--- a/xivsupport/src/main/java/gg/xp/xivsupport/events/fflogs/FflogsEventProcessor.java
+++ b/xivsupport/src/main/java/gg/xp/xivsupport/events/fflogs/FflogsEventProcessor.java
@@ -22,6 +22,7 @@ import gg.xp.xivsupport.events.actlines.events.TickType;
 import gg.xp.xivsupport.events.actlines.events.WipeEvent;
 import gg.xp.xivsupport.events.actlines.events.actorcontrol.VictoryEvent;
 import gg.xp.xivsupport.events.actlines.parsers.FakeFflogsTimeSource;
+import gg.xp.xivsupport.events.state.InCombatChangeEvent;
 import gg.xp.xivsupport.events.state.RawXivCombatantInfo;
 import gg.xp.xivsupport.events.state.RawXivPartyInfo;
 import gg.xp.xivsupport.events.state.XivStateImpl;
@@ -253,6 +254,9 @@ public class FflogsEventProcessor {
 					}
 					else {
 						context.accept(new GenericDamageEvent(source, target, new XivAbility(rawEvent.abilityId()), amount, rawEvent.severity()));
+					}
+					if (amount > 0 && !state.inCombat()) {
+						context.accept(new InCombatChangeEvent(true));
 					}
 				}
 				case "heal", "calculatedheal" -> {

--- a/xivsupport/src/main/java/gg/xp/xivsupport/events/state/XivState.java
+++ b/xivsupport/src/main/java/gg/xp/xivsupport/events/state/XivState.java
@@ -27,9 +27,9 @@ public interface XivState extends SubState {
 	XivPlayerCharacter getPlayer();
 
 	// Note: can be null until we've seen a 01-line
-	XivZone getZone();
+	@Nullable XivZone getZone();
 
-	XivMap getMap();
+	@Nullable XivMap getMap();
 
 	List<XivPlayerCharacter> getPartyList();
 


### PR DESCRIPTION
This allows you to copy cooldown usages from an import (fflogs/act log/etc) onto your custom timeline.

UI will be cleaned up before this gets released.

Steps to use:
1. Import something (fflogs, ACT log, or triggevent session)
2. If using an ACT log or session file, advance the replay to the beginning of the pull that you want to import mits from. This isn't necessary with fflogs since you only import a single pull at a time.
3. Click the new "Record" button in the bottom-right corner of the Plugin Settings -> Timelines tab (see below)
4. Wait for it to run through the entire pull, then click "Accept"
![image](https://github.com/xpdota/event-trigger/assets/14287379/f5c74b6c-bb28-4e1a-bd5c-e87198433513)

By default, each entry will be imported as a job-locked timeline entry without a trigger enabled. 

Recording will replace all previously recorded timeline entries for that zone, but should not remove any custom entries which were not imported/recorded.

Known issues:
- UI sucks
- Doesn't always correctly handle the second phase of doorboss fights, since it may take some time to sync