### PR TITLE
Traceability for easy triggers

### DIFF
--- a/easytriggers/src/main/java/gg/xp/xivsupport/events/triggers/easytriggers/gui/EasyTriggersTab.java
+++ b/easytriggers/src/main/java/gg/xp/xivsupport/events/triggers/easytriggers/gui/EasyTriggersTab.java
@@ -2,6 +2,7 @@ package gg.xp.xivsupport.events.triggers.easytriggers.gui;
 
 import gg.xp.reevent.events.Event;
 import gg.xp.reevent.scan.ScanMe;
+import gg.xp.xivsupport.callouts.RawModifiedCallout;
 import gg.xp.xivsupport.events.ACTLogLineEvent;
 import gg.xp.xivsupport.events.triggers.easytriggers.ActLegacyTriggerImport;
 import gg.xp.xivsupport.events.triggers.easytriggers.EasyTriggers;
@@ -42,6 +43,8 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import static gg.xp.xivsupport.events.triggers.easytriggers.model.EasyTriggerContext.SOURCE_EASY_TRIGGER_KEY;
+
 @ScanMe
 public class EasyTriggersTab implements PluginTab {
 
@@ -66,6 +69,12 @@ public class EasyTriggersTab implements PluginTab {
 				"Make Easy Trigger",
 				Event.class,
 				this::makeTriggerFromEvent));
+		rightClicks.addOption(CustomRightClickOption.forRow(
+				"Go To Easy Trigger",
+				Event.class,
+				this::trySelectTriggerFromCallout,
+				EasyTriggersTab::canSelectTriggerFromCallout
+		));
 		// TODO: good candidate for sub-menus
 //				.addRightClickOption(CustomRightClickOption.forRowWithConverter("Make Easy Trigger", Event.class, Function.identity(), e -> {
 //					container.getComponent(EasyTrig)
@@ -506,5 +515,32 @@ public class EasyTriggersTab implements PluginTab {
 
 	public void bringToFront() {
 		tabReg.activateItem(this);
+	}
+
+	private static boolean canSelectTriggerFromCallout(Event event) {
+		return getEasyTriggerFromCallout(event) != null;
+	}
+
+	private void trySelectTriggerFromCallout(Event event) {
+		EasyTrigger<?> et = getEasyTriggerFromCallout(event);
+		if (et != null) {
+			bringToFront();
+			this.selectTrigger(et);
+		}
+	}
+
+	private static @Nullable EasyTrigger<?> getEasyTriggerFromCallout(Event event) {
+		RawModifiedCallout<?> rawModified = event.getThisOrParentOfType(RawModifiedCallout.class);
+		if (rawModified == null) {
+			return null;
+		}
+		Object source = rawModified.getArguments().get(SOURCE_EASY_TRIGGER_KEY);
+		if (source instanceof EasyTrigger<?> et) {
+			return et;
+		}
+		else {
+			return null;
+		}
+
 	}
 }

--- a/easytriggers/src/main/java/gg/xp/xivsupport/events/triggers/easytriggers/model/EasyTriggerContext.java
+++ b/easytriggers/src/main/java/gg/xp/xivsupport/events/triggers/easytriggers/model/EasyTriggerContext.java
@@ -17,6 +17,7 @@ import java.util.function.Consumer;
 public class EasyTriggerContext {
 
 	private static final Logger log = LoggerFactory.getLogger(EasyTriggerContext.class);
+	public static final String SOURCE_EASY_TRIGGER_KEY = "sourceEasyTrigger";
 
 	private final EventContext context;
 	// for logging
@@ -47,6 +48,7 @@ public class EasyTriggerContext {
 
 	public EasyTriggerContext(EventContext context, EasyTrigger<?> trigger) {
 		this(context, trigger.getName());
+		addVariable(SOURCE_EASY_TRIGGER_KEY, trigger);
 	}
 
 	public <X extends BaseEvent> void runActions(List<Action<? super X>> actions, SequentialTriggerController<X> s, X e1) {


### PR DESCRIPTION
Adds `"sourceEasyTrigger"` to the parameters for callouts from easy triggers, the value of which is the actual `EasyTrigger` instance that caused the callout.

Also adds a right click -> go to easy trigger option for callout events.

Example of how you can use a script to map up easy trigger callouts to their easy trigger names:

```groovy
rawEventStorage.getEventsOfType(ProcessedCalloutEvent).collectEntries {
	def vars = it.parent.arguments
	def source = vars['sourceEasyTrigger']
	if (source == null) {
		return []
	}
	else {
		return ["${source.name}": "${it.ttsText}"]
	}
}
```