### PR TITLE
Clean up events tab and table details

### DIFF
--- a/reevent/src/main/java/gg/xp/reevent/events/Event.java
+++ b/reevent/src/main/java/gg/xp/reevent/events/Event.java
@@ -33,6 +33,7 @@ public interface Event extends Serializable {
 		return false;
 	}
 
+	@Deprecated // Use Groovy methods instead
 	default Map<Field, Object> dumpFields() {
 		return Utils.dumpAllFields(this);
 	}

--- a/xivsupport/src/main/java/gg/xp/xivsupport/gui/groovy/ListTableDisplay.java
+++ b/xivsupport/src/main/java/gg/xp/xivsupport/gui/groovy/ListTableDisplay.java
@@ -2,6 +2,7 @@ package gg.xp.xivsupport.gui.groovy;
 
 import gg.xp.xivsupport.gui.tables.CustomColumn;
 import gg.xp.xivsupport.gui.tables.CustomTableModel;
+import gg.xp.xivsupport.gui.tables.groovy.GroovyColumns;
 import org.codehaus.groovy.runtime.DefaultGroovyMethods;
 import org.jenkinsci.plugins.scriptsecurity.sandbox.groovy.GroovySandbox;
 import org.jetbrains.annotations.Nullable;
@@ -18,7 +19,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 
-import static gg.xp.xivsupport.gui.groovy.GroovyPanel.singleValueConversion;
 
 public class ListTableDisplay {
 	private final List<TableColumn> cols;
@@ -123,7 +123,7 @@ public class ListTableDisplay {
 				.filter(td -> td.applicableTo(value))
 				.findFirst()
 				.map(td -> td.func().apply(value))
-				.orElseGet(() -> singleValueConversion(value));
+				.orElseGet(() -> GroovyColumns.singleValueConversion(value));
 	}
 
 	public static ListTableDisplay autoPropTable() {

--- a/xivsupport/src/main/java/gg/xp/xivsupport/gui/map/MapTab.java
+++ b/xivsupport/src/main/java/gg/xp/xivsupport/gui/map/MapTab.java
@@ -14,8 +14,10 @@ import gg.xp.xivsupport.gui.tables.TableWithFilterAndDetails;
 import gg.xp.xivsupport.gui.tables.filters.EventEntityFilter;
 import gg.xp.xivsupport.gui.tables.filters.GroovyFilter;
 import gg.xp.xivsupport.gui.tables.filters.NonCombatEntityFilter;
+import gg.xp.xivsupport.gui.tables.groovy.GroovyColumns;
 import gg.xp.xivsupport.models.XivCombatant;
 import gg.xp.xivsupport.models.XivEntity;
+import groovy.lang.PropertyValue;
 
 import javax.swing.*;
 import java.awt.*;
@@ -30,7 +32,7 @@ import java.util.stream.Collectors;
 @ScanMe
 public class MapTab extends JPanel {
 
-	private final TableWithFilterAndDetails<XivCombatant, Map.Entry<Field, Object>> table;
+	private final TableWithFilterAndDetails<XivCombatant, PropertyValue> table;
 	private final RefreshLoop<MapTab> mapRefresh;
 	private final MapPanel mapPanel;
 	private final MapDataController mapDataController;
@@ -54,18 +56,7 @@ public class MapTab extends JPanel {
 
 		table = TableWithFilterAndDetails.builder("Combatants",
 						() -> mdc.getCombatants().stream().sorted(Comparator.comparing(XivEntity::getId)).collect(Collectors.toList()),
-						combatant -> {
-							if (combatant == null) {
-								return Collections.emptyList();
-							}
-							else {
-								return Utils.dumpAllFields(combatant)
-										.entrySet()
-										.stream()
-										.filter(e -> !"serialVersionUID".equals(e.getKey().getName()))
-										.collect(Collectors.toList());
-							}
-						})
+						GroovyColumns::getValues)
 				.addMainColumn(StandardColumns.entityIdColumn)
 				.addMainColumn(StandardColumns.nameJobColumn)
 				.addMainColumn(StandardColumns.sortedStatusEffectsColumn(mdc::buffsOnCombatant))
@@ -75,13 +66,8 @@ public class MapTab extends JPanel {
 				.addMainColumn(StandardColumns.hpColumnWithUnresolved(mdc::unresolvedDamage))
 //				.addMainColumn(StandardColumns.mpColumn)
 //				.addMainColumn(StandardColumns.posColumn)
-				.addDetailsColumn(StandardColumns.fieldName)
-				.addDetailsColumn(StandardColumns.fieldValue)
-				.addDetailsColumn(StandardColumns.identity)
-				.addDetailsColumn(StandardColumns.fieldType)
-				.addDetailsColumn(StandardColumns.fieldDeclaredIn)
+				.apply(GroovyColumns::addDetailColumns)
 				.setSelectionEquivalence((a, b) -> a.getId() == b.getId())
-				.setDetailsSelectionEquivalence((a, b) -> a.getKey().equals(b.getKey()))
 				.addFilter(EventEntityFilter::selfFilter)
 				.addFilter(NonCombatEntityFilter::new)
 				.addFilter(GroovyFilter.forClass(XivCombatant.class, mgr, "it"))

--- a/xivsupport/src/main/java/gg/xp/xivsupport/gui/tables/CustomTableModel.java
+++ b/xivsupport/src/main/java/gg/xp/xivsupport/gui/tables/CustomTableModel.java
@@ -19,6 +19,8 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BiPredicate;
+import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
@@ -39,6 +41,15 @@ public class CustomTableModel<X> extends AbstractTableModel {
 		public CustomTableModelBuilder<B> addColumn(CustomColumn<? super B> colDef) {
 			columns.add(colDef);
 			return this;
+		}
+
+		public CustomTableModelBuilder<B> apply(Consumer<? super CustomTableModelBuilder<B>> func) {
+			func.accept(this);
+			return this;
+		}
+
+		public CustomTableModelBuilder<B> transform(Function<? super CustomTableModelBuilder<B>, CustomTableModelBuilder<B>> func) {
+			return func.apply(this);
 		}
 
 		public CustomTableModel<B> build() {

--- a/xivsupport/src/main/java/gg/xp/xivsupport/gui/tables/TableWithFilterAndDetails.java
+++ b/xivsupport/src/main/java/gg/xp/xivsupport/gui/tables/TableWithFilterAndDetails.java
@@ -22,6 +22,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BiPredicate;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -182,7 +183,7 @@ public final class TableWithFilterAndDetails<X, D> extends TitleBorderFullsizePa
 		});
 		c.weighty = 1;
 
-		JTable detailsTable = new JTable(detailsModel);
+		JTable detailsTable = detailsModel.makeTable();
 		JScrollPane detailsScroller = new JScrollPane(detailsTable);
 		detailsScroller.setPreferredSize(detailsScroller.getMaximumSize());
 
@@ -435,6 +436,15 @@ public final class TableWithFilterAndDetails<X, D> extends TitleBorderFullsizePa
 			setAppendOrPruneOnly(true);
 			this.fixedData = fixedData;
 			return this;
+		}
+
+		public TableWithFilterAndDetailsBuilder<X, D> apply(Consumer<? super TableWithFilterAndDetailsBuilder<X, D>> func) {
+			func.accept(this);
+			return this;
+		}
+
+		public TableWithFilterAndDetailsBuilder<X, D> transform(Function<? super TableWithFilterAndDetailsBuilder<X, D>, TableWithFilterAndDetailsBuilder<X, D>> func) {
+			return func.apply(this);
 		}
 	}
 

--- a/xivsupport/src/main/java/gg/xp/xivsupport/gui/tables/groovy/GroovyColumns.java
+++ b/xivsupport/src/main/java/gg/xp/xivsupport/gui/tables/groovy/GroovyColumns.java
@@ -1,0 +1,117 @@
+package gg.xp.xivsupport.gui.tables.groovy;
+
+import gg.xp.xivsupport.gui.groovy.GroovyPanel;
+import gg.xp.xivsupport.gui.tables.CustomColumn;
+import gg.xp.xivsupport.gui.tables.CustomTableModel;
+import gg.xp.xivsupport.gui.tables.TableWithFilterAndDetails;
+import groovy.lang.GroovyRuntimeException;
+import groovy.lang.PropertyValue;
+import org.codehaus.groovy.runtime.DefaultGroovyMethods;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.swing.*;
+import javax.swing.table.DefaultTableCellRenderer;
+import javax.swing.table.TableCellRenderer;
+import java.awt.*;
+import java.lang.reflect.Array;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+public final class GroovyColumns {
+	private static final Logger log = LoggerFactory.getLogger(GroovyColumns.class);
+	public static final CustomColumn<PropertyValue> propName = new CustomColumn<>("Name", PropertyValue::getName);
+	public static final CustomColumn<PropertyValue> propVal = new CustomColumn<>("Value", propertyValue -> {
+		try {
+			return propertyValue.getValue();
+		}
+		catch (Throwable t) {
+			return t;
+		}
+	}, c -> {
+		c.setCellRenderer(new DefaultTableCellRenderer() {
+			@Override
+			public Component getTableCellRendererComponent(JTable table, Object value, boolean isSelected, boolean hasFocus, int row, int column) {
+				value = singleValueConversion(value);
+				return super.getTableCellRendererComponent(table, value, isSelected, hasFocus, row, column);
+			}
+		});
+	});
+	public static final CustomColumn<PropertyValue> propType = new CustomColumn<>("Type", PropertyValue::getType);
+
+	private GroovyColumns() {
+	}
+
+	public static List<PropertyValue> getValues(Object obj) {
+		if (obj == null) {
+			return Collections.emptyList();
+		}
+		else {
+			return DefaultGroovyMethods.getMetaPropertyValues(obj)
+					.stream()
+					.filter(GroovyColumns::isReadable)
+					.filter(pv -> !"serialVersionUID".equals(pv.getName()))
+					.toList();
+		}
+	}
+
+	public static boolean isReadable(PropertyValue pv) {
+		try {
+			pv.getValue();
+			return true;
+		}
+		catch (GroovyRuntimeException gre) {
+			if (gre.getMessage() != null && gre.getMessage().startsWith("Cannot read write-only property")) {
+				return false;
+			}
+			else {
+				throw gre;
+			}
+		}
+	}
+
+	public static boolean propEquals(PropertyValue a, PropertyValue b) {
+		return Objects.equals(a.getName(), b.getName());
+	}
+
+	public static void addColumns(CustomTableModel.CustomTableModelBuilder<PropertyValue> builder) {
+		builder.addColumn(propName)
+				.addColumn(propVal)
+				.addColumn(propType);
+		builder.setItemEquivalence(GroovyColumns::propEquals);
+	}
+
+	public static void addDetailColumns(TableWithFilterAndDetails.TableWithFilterAndDetailsBuilder<?, PropertyValue> builder) {
+		builder.addDetailsColumn(propName)
+				.addDetailsColumn(propVal)
+				.addDetailsColumn(propType);
+		builder.setDetailsSelectionEquivalence(GroovyColumns::propEquals);
+	}
+
+	@SuppressWarnings("MalformedFormatString")
+	public static Object singleValueConversion(Object obj) {
+		if (obj == null) {
+			return "(null)";
+		}
+		if (obj instanceof Byte || obj instanceof Integer || obj instanceof Long || obj instanceof Short) {
+			return String.format("%d (0x%x)", obj, obj);
+		}
+		if (obj.getClass().isArray()) {
+			int length = Array.getLength(obj);
+			List<Object> converted = new ArrayList<>();
+			for (int i = 0; i < length; i++) {
+				converted.add(Array.get(obj, i));
+			}
+			return converted.stream()
+					.map(GroovyColumns::singleValueConversion)
+					.map(Object::toString)
+					.collect(Collectors.joining(", ", "[", "]"));
+		}
+		return obj;
+
+	}
+}
+

--- a/xivsupport/src/main/java/gg/xp/xivsupport/gui/tabs/EventsTabFactory.java
+++ b/xivsupport/src/main/java/gg/xp/xivsupport/gui/tabs/EventsTabFactory.java
@@ -14,7 +14,6 @@ import gg.xp.xivsupport.groovy.GroovyManager;
 import gg.xp.xivsupport.gui.tables.CustomColumn;
 import gg.xp.xivsupport.gui.tables.GlobalGuiOptions;
 import gg.xp.xivsupport.gui.tables.RightClickOptionRepo;
-import gg.xp.xivsupport.gui.tables.StandardColumns;
 import gg.xp.xivsupport.gui.tables.TableWithFilterAndDetails;
 import gg.xp.xivsupport.gui.tables.filters.AbilityResolutionFilter;
 import gg.xp.xivsupport.gui.tables.filters.EventAbilityOrBuffFilter;
@@ -24,6 +23,7 @@ import gg.xp.xivsupport.gui.tables.filters.GroovyFilter;
 import gg.xp.xivsupport.gui.tables.filters.PullNumberFilter;
 import gg.xp.xivsupport.gui.tables.filters.QuickFilters;
 import gg.xp.xivsupport.gui.tables.filters.SystemEventFilter;
+import gg.xp.xivsupport.gui.tables.groovy.GroovyColumns;
 import gg.xp.xivsupport.gui.tables.renderers.AbilityEffectListRenderer;
 import gg.xp.xivsupport.gui.tables.renderers.ActionAndStatusRenderer;
 import gg.xp.xivsupport.gui.tables.renderers.NameJobRenderer;
@@ -32,20 +32,17 @@ import gg.xp.xivsupport.persistence.gui.BooleanSettingGui;
 import gg.xp.xivsupport.persistence.settings.BooleanSetting;
 import gg.xp.xivsupport.replay.ReplayController;
 import gg.xp.xivsupport.replay.gui.ReplayAdvancePseudoFilter;
+import groovy.lang.PropertyValue;
 import org.jetbrains.annotations.Nullable;
 import org.picocontainer.MutablePicoContainer;
 
 import javax.swing.*;
 import java.awt.*;
 import java.lang.ref.WeakReference;
-import java.lang.reflect.Field;
-import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 
 @ScanMe
 public class EventsTabFactory {
@@ -75,19 +72,9 @@ public class EventsTabFactory {
 		displayIdsSetting.addAndRunListener(() -> asRenderer.setShowId(displayIdsSetting.get()));
 		displayIdsSetting.addAndRunListener(() -> nameJobRenderer.setShowId(displayIdsSetting.get()));
 		TimeDisplayController tdc = new TimeDisplayController();
-		TableWithFilterAndDetails<Event, Map.Entry<Field, Object>> table = TableWithFilterAndDetails.builder("Events", rawStorage::getEvents,
-						currentEvent -> {
-							if (currentEvent == null) {
-								return Collections.emptyList();
-							}
-							else {
-								return currentEvent.dumpFields()
-										.entrySet()
-										.stream()
-										.filter(e -> !"serialVersionUID".equals(e.getKey().getName()))
-										.collect(Collectors.toList());
-							}
-						})
+		TableWithFilterAndDetails<Event, PropertyValue> table = TableWithFilterAndDetails.builder("Events",
+						rawStorage::getEvents,
+						GroovyColumns::getValues)
 				.addMainColumn(tdc.getColumnDef())
 				.addMainColumn(new CustomColumn<>("Type", e -> e.getClass().getSimpleName()))
 				.addMainColumn(new CustomColumn<>("Source", e -> e instanceof HasSourceEntity ? ((HasSourceEntity) e).getSource() : null, c -> c.setCellRenderer(nameJobRenderer)))
@@ -101,15 +88,7 @@ public class EventsTabFactory {
 					}
 					return null;
 				}, c -> c.setCellRenderer(new AbilityEffectListRenderer())))
-				.addMainColumn(new CustomColumn<>("Parent", e -> {
-					Event parent = e.getParent();
-					return parent == null ? null : parent.getClass().getSimpleName();
-				}))
-				.addDetailsColumn(StandardColumns.fieldName)
-				.addDetailsColumn(StandardColumns.fieldValue)
-				.addDetailsColumn(StandardColumns.identity)
-				.addDetailsColumn(StandardColumns.fieldType)
-				.addDetailsColumn(StandardColumns.fieldDeclaredIn)
+				.apply(GroovyColumns::addDetailColumns)
 				.withRightClickRepo(rightClicks)
 				.addFilter(SystemEventFilter::new)
 				.addFilter(EventClassFilterFilter::new)

--- a/xivsupport/src/main/resources/te_changelog.html
+++ b/xivsupport/src/main/resources/te_changelog.html
@@ -1,5 +1,10 @@
 <html lang="en">
     <body style="margin: 5px 20px 5px 20px">
+        <h2>July 15, 2024</h2>
+        <ul>
+            <li>Cleaned up events tab.</li>
+            <li>Revamped table details to better show which properties can be used in scripts.</li>
+        </ul>
         <h2>July 13, 2024</h2>
         <ul>
             <li>More Ex1</li>


### PR DESCRIPTION
Now uses Groovy's definition of "Properties" for all the tables, rather than directly dumping fields. This means that everything you can see in the details pane is usable as a property in scripts and callouts.